### PR TITLE
fix: update task addition logic

### DIFF
--- a/src/task/manager/TaskManager.java
+++ b/src/task/manager/TaskManager.java
@@ -29,19 +29,16 @@ public class TaskManager {
     return store.getTaskById(id);
   }
 
-  public Optional<RegularTask> addTask(final RegularTask task) {
-    return Optional.ofNullable(
-        TypeSafeCaster.castSafely(store.addTask(task.getId(), task), RegularTask.class));
+  public RegularTask addTask(final RegularTask task) {
+    return TypeSafeCaster.castSafely(store.addTask(task), RegularTask.class);
   }
 
-  public Optional<EpicTask> addTask(final EpicTask task) {
-    return Optional.ofNullable(
-        TypeSafeCaster.castSafely(store.addTask(task.getId(), task), EpicTask.class));
+  public EpicTask addTask(final EpicTask task) {
+    return TypeSafeCaster.castSafely(store.addTask(task), EpicTask.class);
   }
 
-  public Optional<SubTask> addTask(final SubTask task) {
-    return Optional.ofNullable(
-        TypeSafeCaster.castSafely(store.addTask(task.getId(), task), SubTask.class));
+  public SubTask addTask(final SubTask task) {
+    return TypeSafeCaster.castSafely(store.addTask(task), SubTask.class);
   }
 
   public Task updateTask(final Task task) {

--- a/src/task/store/TaskRepository.java
+++ b/src/task/store/TaskRepository.java
@@ -12,19 +12,24 @@ import task.model.Task;
  */
 public class TaskRepository {
     private final Map<Integer, Task> taskStore = new HashMap<>();
-    
-    /**
-     * Adds a new task to the repository. If a task with the same ID already exists,
-     * it is replaced with the specified task.
-     *
-     * @param id    the unique identifier for the task
-     * @param task  the task to be added or replaced
-     * @return an {@link Optional} containing the previous task associated with the ID, or an empty {@link Optional} if none existed
-     * @throws NullPointerException if the provided task is {@code null}
-     */
-    public Optional<Task> addTask(final int id, final Task task) {
+
+  /**
+   * Adds a new task to the repository. The task is identified by its unique ID, and if a task with
+   * the same ID already exists in the repository, the operation will fail.
+   *
+   * @param task the task to be added to the repository
+   * @return the {@link Task} object added to the repository
+   * @throws NullPointerException if the provided task is {@code null}
+   * @throws IllegalArgumentException if a task with the same ID already exists in the repository
+   */
+  public Task addTask(final Task task) {
         Objects.requireNonNull(task, "Task can't be null");
-        return Optional.ofNullable(taskStore.put(id, task));
+    int taskId = task.getId();
+    if (taskStore.containsKey(taskId)) {
+      throw new IllegalArgumentException("Task with the same ID already exists: " + taskId);
+    }
+    taskStore.put(taskId, task);
+    return task;
     }
 
     /**


### PR DESCRIPTION
Revised task addition methods for direct Task instances and unique IDs.

- Updated `addTask` methods to return specific Task instances directly.
- Eliminated ID parameter in `addTask` to extract IDs from the task object.
- Enforced unique task IDs by throwing an exception for duplicates.
- Updated JavaDocs to reflect the changes in behavior and exceptions.