### PR TITLE
rename date fields to creationDateTime/updateDateTime

### DIFF
--- a/src/com/tasktracker/task/model/implementations/EpicTask.java
+++ b/src/com/tasktracker/task/model/implementations/EpicTask.java
@@ -23,8 +23,8 @@ public final class EpicTask extends Task {
    * @param status the current status of the task; cannot be null
    * @param subtaskIds a set of IDs representing the subtasks associated with this epic task; cannot
    *     contain negative values
-   * @param creationDate the creation date of the task; cannot be null
-   * @param updateDate the last update time of the task; cannot be null
+   * @param creationDateTime the creation date of the task; cannot be null
+   * @param updateDateTime the last update time of the task; cannot be null
    * @throws ValidationException if any validation criteria are not met
    * @throws NullPointerException if any parameter marked as non-null is null
    */
@@ -34,10 +34,10 @@ public final class EpicTask extends Task {
       final String description,
       final TaskStatus status,
       final Set<Integer> subtaskIds,
-      final LocalDateTime creationDate,
-      final LocalDateTime updateDate)
+      final LocalDateTime creationDateTime,
+      final LocalDateTime updateDateTime)
       throws ValidationException, NullPointerException {
-    super(id, title, description, status, creationDate, updateDate);
+    super(id, title, description, status, creationDateTime, updateDateTime);
     this.subtaskIds = getValidatedSubTaskIds(subtaskIds);
   }
 
@@ -80,18 +80,16 @@ public final class EpicTask extends Task {
         + super.getId()
         + ", title='"
         + super.getTitle()
-        + '\''
         + ", description='"
         + super.getDescription()
-        + '\''
         + ", status="
         + super.getStatus()
+        + ", subtaskIds="
+        + subtaskIds.toString()
         + ", creationDate="
         + super.getCreationDate()
         + ", updateDate="
         + super.getUpdateDate()
-        + ", subtaskIds="
-        + subtaskIds.toString()
         + '}';
   }
 }

--- a/src/com/tasktracker/task/model/implementations/RegularTask.java
+++ b/src/com/tasktracker/task/model/implementations/RegularTask.java
@@ -18,8 +18,8 @@ public final class RegularTask extends Task {
    * @param description the description of the task; cannot be null or shorter than the minimum
    *     required length
    * @param status the current status of the task, as defined in {@link TaskStatus}; cannot be null
-   * @param creationDate the creation date of the task; cannot be null
-   * @param updateDate the last update date of the task; cannot be null
+   * @param creationDateTime the creation date of the task; cannot be null
+   * @param updateDateTime the last update date of the task; cannot be null
    * @throws ValidationException if any input validation fails
    * @throws NullPointerException if any parameter is null
    */
@@ -28,15 +28,15 @@ public final class RegularTask extends Task {
       final String title,
       final String description,
       final TaskStatus status,
-      final LocalDateTime creationDate,
-      final LocalDateTime updateDate)
+      final LocalDateTime creationDateTime,
+      final LocalDateTime updateDateTime)
       throws ValidationException, NullPointerException {
-    super(id, title, description, status, creationDate, updateDate);
+    super(id, title, description, status, creationDateTime, updateDateTime);
   }
 
   /**
-   * Returns a string representation of this RegularTask, including its ID, title, description, and
-   * status.
+   * Returns a string representation of this RegularTask, including its ID, title, description,
+   * status, creation date, and update date.
    *
    * @return a string representation of the com.tasktracker.task
    */
@@ -53,6 +53,10 @@ public final class RegularTask extends Task {
         + '\''
         + ", status="
         + super.getStatus()
+        + ", creationDate="
+        + super.getCreationDate()
+        + ", updateDate="
+        + super.getUpdateDate()
         + '}';
   }
 }

--- a/src/com/tasktracker/task/model/implementations/SubTask.java
+++ b/src/com/tasktracker/task/model/implementations/SubTask.java
@@ -21,8 +21,8 @@ public final class SubTask extends Task {
    *     length
    * @param status the current status of the subtask; cannot be null
    * @param epicTaskId the ID of the epic task to which this subtask belongs; must be non-negative
-   * @param creationDate the creation date of the subtask; cannot be null
-   * @param updateDate the last update time of the subtask; cannot be null
+   * @param creationDateTime the creation date of the subtask; cannot be null
+   * @param updateDateTime the last update time of the subtask; cannot be null
    * @throws ValidationException if any validation rules for parameters fail
    * @throws NullPointerException if any parameter is null where not allowed
    */
@@ -32,10 +32,10 @@ public final class SubTask extends Task {
       final String description,
       final TaskStatus status,
       final int epicTaskId,
-      final LocalDateTime creationDate,
-      final LocalDateTime updateDate)
+      final LocalDateTime creationDateTime,
+      final LocalDateTime updateDateTime)
       throws ValidationException, NullPointerException {
-    super(id, title, description, status, creationDate, updateDate);
+    super(id, title, description, status, creationDateTime, updateDateTime);
     this.epicTaskId = getValidEpicTaskId(epicTaskId);
   }
 
@@ -74,10 +74,8 @@ public final class SubTask extends Task {
         + super.getId()
         + ", title='"
         + super.getTitle()
-        + '\''
         + ", description='"
         + super.getDescription()
-        + '\''
         + ", status="
         + super.getStatus()
         + ", epicTaskId="


### PR DESCRIPTION
**Description:**

- Updated constructors and Javadoc in `EpicTask`, `RegularTask`, and `SubTask`.
- Adjusted calls to superclass constructors to use new field names.
- Enhanced `toString` methods to reflect renamed fields in all affected classes.