### PR TITLE
Streamline task history management and API for clarity

### DIFF
--- a/src/main/java/com/tasktracker/Main.java
+++ b/src/main/java/com/tasktracker/Main.java
@@ -17,12 +17,88 @@ import java.util.Optional;
 public class Main {
   public static void main(String[] args) {
     // Run different test sets
+    testUserScenario();
     testBasicCrudOperations();
     testAdditionalEpicScenarios();
     testRemovingTasks();
     testUpdateEpicAndSubtaskStatus();
     testRemoveTasksByType();
     testBoundaryCases();
+  }
+
+  private static void testUserScenario() {
+    TaskManager tm = Managers.getDefault();
+
+    // Create two regular tasks
+    RegularTask regularTask1 =
+        tm.addTask(
+            new RegularTaskCreationDTO(
+                "Regular Task 1", "Regular task 1 description is long enough"));
+    RegularTask regularTask2 =
+        tm.addTask(
+            new RegularTaskCreationDTO(
+                "Regular Task 2", "Regular task 2 description is long enough"));
+
+    // Create an epic with three subtasks
+    EpicTask epicWithSubtasks =
+        tm.addTask(
+            new EpicTaskCreationDTO("Epic With Subtasks", "Epic with three subtasks description"));
+    SubTask subTask1 =
+        tm.addTask(
+            new SubTaskCreationDTO(
+                "Subtask 1   ", "Subtask 1 description is long enough", epicWithSubtasks.getId()));
+    SubTask subTask2 =
+        tm.addTask(
+            new SubTaskCreationDTO(
+                "Subtask 2   ", "Subtask 2 description is long enough", epicWithSubtasks.getId()));
+    SubTask subTask3 =
+        tm.addTask(
+            new SubTaskCreationDTO(
+                "Subtask 3   ", "Subtask 3 description is long enough", epicWithSubtasks.getId()));
+
+    // Create an epic without subtasks
+    EpicTask epicWithoutSubtasks =
+        tm.addTask(
+            new EpicTaskCreationDTO(
+                "Epic Without Subtasks", "Epic without any subtasks description"));
+
+    // Access tasks in different order to build the history
+    tm.getTask(regularTask1.getId());
+    printHistory(tm);
+    tm.getTask(epicWithSubtasks.getId());
+    printHistory(tm);
+    tm.getTask(subTask2.getId());
+    printHistory(tm);
+    tm.getTask(regularTask2.getId());
+    printHistory(tm);
+    tm.getTask(epicWithoutSubtasks.getId());
+    printHistory(tm);
+    tm.getTask(subTask1.getId());
+    printHistory(tm);
+    tm.getTask(subTask3.getId());
+    printHistory(tm);
+    tm.getTask(epicWithSubtasks.getId());
+    printHistory(tm);
+
+    System.out.println("Final history (no duplicates expected):");
+    printHistory(tm);
+
+    // Remove a task present in history (e.g., Regular Task 1)
+    tm.removeTaskById(regularTask1.getId());
+    System.out.println("History after deleting Regular Task 1:");
+    printHistory(tm);
+
+    // Remove the epic with subtasks and ensure both the epic and its subtasks are removed from
+    // history
+    tm.removeTaskById(epicWithSubtasks.getId());
+    System.out.println("History after deleting epic with subtasks:");
+    printHistory(tm);
+  }
+
+  private static void printHistory(TaskManager tm) {
+    System.out.print("History: ");
+    tm.getHistory().forEach(task -> System.out.print(task.getId() + " "));
+    System.out.println();
   }
 
   /** Basic CRUD operations: creation, reading, updating, printing. */
@@ -70,7 +146,7 @@ public class Main {
     printAll(tm);
 
     // Check one of the tasks by ID
-    Optional<Task> maybeReg2 = tm.getTaskById(regTask2.getId());
+    Optional<Task> maybeReg2 = tm.getTask(regTask2.getId());
     System.out.println("Check getTaskById for RegularTask2: " + maybeReg2);
 
     System.out.println("====================================\n");

--- a/src/main/java/com/tasktracker/collections/CustomLinkedHashMap.java
+++ b/src/main/java/com/tasktracker/collections/CustomLinkedHashMap.java
@@ -1,0 +1,822 @@
+package com.tasktracker.collections;
+
+import java.util.*;
+
+public class CustomLinkedHashMap<K, V>
+    implements SequencedMap<K, V>, Iterable<V>, Comparable<CustomLinkedHashMap<K, V>> {
+  public static final String MAP_IS_EMPTY_GET_LAST_VALUE = "Map is empty (getLast value)";
+  public static final String MAP_IS_EMPTY_GET_FIRST_VALUE = "Map is empty (getFirst value)";
+  public static final String KEY_CAN_T_BE_NULL = "key can't be null";
+  public static final String VALUE_CAN_T_BE_NULL = "value can't be null";
+  public static final String NODE_CAN_T_BE_NULL = "node can't be null";
+  public static final String MAP_IS_EMPTY_GET_FIRST_KEY = "Map is empty (getFirst key)";
+  private final HashMap<K, Node<K, V>> hashMap = new HashMap<>();
+  private EntrySetView entrySetView = null;
+  private ReversedCustomLinkedHashMapView<K, V> reversedMapView = null;
+  private ValuesView valuesView = null;
+  private KeySetView keySetView = null;
+  private Node<K, V> lastNode = null;
+  private Node<K, V> firstNode = null;
+
+  @Override
+  public SequencedMap<K, V> reversed() {
+    if (reversedMapView == null) {
+      reversedMapView = new ReversedCustomLinkedHashMapView<>(this);
+    }
+    return reversedMapView;
+  }
+
+  @Override
+  public Entry<K, V> firstEntry() {
+    if (firstNode == null) return null;
+    return firstNode.getImmutableEntry();
+  }
+
+  @Override
+  public Entry<K, V> lastEntry() {
+    if (lastNode == null) return null;
+    return lastNode.getImmutableEntry();
+  }
+
+  private AbstractMap.SimpleImmutableEntry<K, V> pollNodeAndGetEntry(Node<K, V> node) {
+    if (node == null) return null;
+    unlinkNode(node);
+    hashMap.remove(node.getKey());
+    return node.getImmutableEntry();
+  }
+
+  @Override
+  public Entry<K, V> pollFirstEntry() {
+    return pollNodeAndGetEntry(firstNode);
+  }
+
+  @Override
+  public Entry<K, V> pollLastEntry() {
+    return pollNodeAndGetEntry(lastNode);
+  }
+
+  private V putInPosition(K k, V v, boolean atFront) {
+    Objects.requireNonNull(k, KEY_CAN_T_BE_NULL);
+    Objects.requireNonNull(v, VALUE_CAN_T_BE_NULL);
+    final var replacedNode = hashMap.get(k);
+    if (replacedNode != null) {
+      var oldValue = replacedNode.getValue();
+      replacedNode.setValue(v);
+      return oldValue;
+    }
+    final var newNode = new Node<>(k, v, null, null);
+    if (hashMap.isEmpty()) {
+      firstNode = newNode;
+      lastNode = newNode;
+      hashMap.put(k, newNode);
+    } else {
+      if (atFront) {
+        firstNode.setPrevious(newNode);
+        newNode.setNext(firstNode);
+        firstNode = newNode;
+      } else {
+        lastNode.setNext(newNode);
+        newNode.setPrevious(lastNode);
+        lastNode = newNode;
+      }
+      hashMap.put(k, newNode);
+    }
+    return null;
+  }
+
+  @Override
+  public V putFirst(K k, V v) {
+    return putInPosition(k, v, true);
+  }
+
+  @Override
+  public V putLast(K k, V v) {
+    return putInPosition(k, v, false);
+  }
+
+  @Override
+  public int size() {
+    return hashMap.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return hashMap.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    Objects.requireNonNull(key, KEY_CAN_T_BE_NULL);
+    return hashMap.containsKey(key);
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    Objects.requireNonNull(value, VALUE_CAN_T_BE_NULL);
+    for (Node<K, V> node = firstNode; node != null; node = node.getNext()) {
+      if (Objects.equals(node.getValue(), value)) return true;
+    }
+    return false;
+  }
+
+  @Override
+  public V get(Object key) {
+    Objects.requireNonNull(key, KEY_CAN_T_BE_NULL);
+    Node<K, V> node = hashMap.get(key);
+    return (node != null) ? node.getValue() : null;
+  }
+
+  @Override
+  public V put(K key, V value) {
+    Objects.requireNonNull(key, KEY_CAN_T_BE_NULL);
+    Objects.requireNonNull(value, VALUE_CAN_T_BE_NULL);
+    var newNode = new Node<>(key, value, null, lastNode);
+    if (hashMap.isEmpty()) {
+      hashMap.put(key, newNode);
+      lastNode = newNode;
+      firstNode = newNode;
+      return null;
+    }
+    var removedNode = hashMap.put(key, newNode);
+    if (removedNode != null) {
+      replaceNode(removedNode, newNode);
+      return removedNode.getValue();
+    }
+    lastNode.setNext(newNode);
+    lastNode = newNode;
+    return null;
+  }
+
+  @Override
+  public V remove(Object key) {
+    Objects.requireNonNull(key, KEY_CAN_T_BE_NULL);
+    Node<K, V> removedNode = hashMap.remove(key);
+    if (removedNode != null) {
+      unlinkNode(removedNode);
+      return removedNode.getValue();
+    }
+    return null;
+  }
+
+  private void unlinkNode(Node<K, V> node) {
+    Objects.requireNonNull(node, NODE_CAN_T_BE_NULL);
+    var previousNode = node.getPrevious();
+    var nextNode = node.getNext();
+    if (previousNode != null) {
+      previousNode.setNext(nextNode);
+    } else {
+      firstNode = nextNode;
+    }
+    if (nextNode != null) {
+      nextNode.setPrevious(previousNode);
+    } else {
+      lastNode = previousNode;
+    }
+  }
+
+  private void replaceNode(Node<K, V> nodeToUnlink, Node<K, V> nodeToInsert) {
+    Objects.requireNonNull(nodeToUnlink, "nodeToUnlink can't be Null");
+    Objects.requireNonNull(nodeToInsert, "nodeToInsert can't be Null");
+    var previousNode = nodeToUnlink.getPrevious();
+    var nextNode = nodeToUnlink.getNext();
+    if (previousNode != null) {
+      previousNode.setNext(nodeToInsert);
+      nodeToInsert.setPrevious(previousNode);
+    } else {
+      firstNode = nodeToInsert;
+    }
+    if (nextNode != null) {
+      nextNode.setPrevious(nodeToInsert);
+      nodeToInsert.setNext(nextNode);
+    } else {
+      lastNode = nodeToInsert;
+    }
+  }
+
+  @Override
+  public void clear() {
+    hashMap.clear();
+    firstNode = null;
+    lastNode = null;
+    reversedMapView = null;
+    valuesView = null;
+    entrySetView = null;
+    keySetView = null;
+  }
+
+  @Override
+  public SequencedSet<K> keySet() {
+    if (keySetView == null) {
+      keySetView = new KeySetView();
+    }
+    return keySetView;
+  }
+
+  @Override
+  public SequencedCollection<V> values() {
+    if (valuesView == null) {
+      valuesView = new ValuesView();
+    }
+    return valuesView;
+  }
+
+  @Override
+  public SequencedSet<Entry<K, V>> entrySet() {
+    if (entrySetView == null) {
+      entrySetView = new EntrySetView();
+    }
+    return entrySetView;
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    Objects.requireNonNull(m);
+    for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
+      this.putLast(e.getKey(), e.getValue());
+    }
+  }
+
+  @Override
+  public Iterator<V> iterator() {
+    return new LinkedIterator<>(firstNode, true, Node::getValue);
+  }
+
+  @Override
+  public int compareTo(CustomLinkedHashMap<K, V> o) {
+    Objects.requireNonNull(o, "Cannot compare to a null map");
+    return Integer.compare(this.size(), o.size());
+  }
+
+  private <T> T getElementFromSequencedNode(
+      Node<K, V> node,
+      java.util.function.Function<Node<K, V>, T> extractor,
+      String exceptionMessage) {
+    if (node == null) {
+      throw new NoSuchElementException(exceptionMessage);
+    }
+    return extractor.apply(node);
+  }
+
+  @Override
+  public int hashCode() {
+    int h = 0;
+    for (Map.Entry<K, V> entry : entrySet()) {
+      h += entry.hashCode();
+    }
+    return h;
+  }
+
+  @Override
+  public boolean remove(Object key, Object value) {
+    Objects.requireNonNull(key, KEY_CAN_T_BE_NULL);
+    Node<K, V> node = hashMap.get(key);
+    if (node != null && Objects.equals(node.getValue(), value)) {
+      remove(key);
+      return true;
+    }
+    return false;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) return true;
+    if (!(obj instanceof Map<?, ?> m)) return false;
+    if (m.size() != size()) return false;
+    try {
+      for (Map.Entry<K, V> e : entrySet()) {
+        K key = e.getKey();
+        V value = e.getValue();
+        if (value == null) {
+          if (!(m.get(key) == null && m.containsKey(key))) return false;
+        } else {
+          if (!value.equals(m.get(key))) return false;
+        }
+      }
+    } catch (ClassCastException | NullPointerException unused) {
+      return false;
+    }
+    return true;
+  }
+
+  private static class Node<K, V> {
+    private final K key;
+
+    private V value;
+    private Node<K, V> next;
+    private Node<K, V> previous;
+
+    public Node(K key, V value, Node<K, V> next, Node<K, V> previous) {
+      this.key = key;
+      this.value = value;
+      this.next = next;
+      this.previous = previous;
+    }
+
+    public K getKey() {
+      return key;
+    }
+
+    public V getValue() {
+      return value;
+    }
+
+    public void setValue(V value) {
+      this.value = value;
+    }
+
+    public AbstractMap.SimpleImmutableEntry<K, V> getImmutableEntry() {
+      return new AbstractMap.SimpleImmutableEntry<>(key, value);
+    }
+
+    public Node<K, V> getNext() {
+      return next;
+    }
+
+    public void setNext(Node<K, V> next) {
+      this.next = next;
+    }
+
+    public Node<K, V> getPrevious() {
+      return previous;
+    }
+
+    public void setPrevious(Node<K, V> previous) {
+      this.previous = previous;
+    }
+  }
+
+  private static final class ReversedCustomLinkedHashMapView<K, V> implements SequencedMap<K, V> {
+    private final CustomLinkedHashMap<K, V> originalMap;
+
+    ReversedCustomLinkedHashMapView(CustomLinkedHashMap<K, V> original) {
+      Objects.requireNonNull(original, "Original map cannot be null for ReversedMapView");
+      this.originalMap = original;
+    }
+
+    @Override
+    public SequencedMap<K, V> reversed() {
+      return originalMap;
+    }
+
+    @Override
+    public Entry<K, V> firstEntry() {
+      return originalMap.lastEntry();
+    }
+
+    @Override
+    public Entry<K, V> lastEntry() {
+      return originalMap.firstEntry();
+    }
+
+    @Override
+    public Entry<K, V> pollFirstEntry() {
+      return originalMap.pollLastEntry();
+    }
+
+    @Override
+    public Entry<K, V> pollLastEntry() {
+      return originalMap.pollFirstEntry();
+    }
+
+    @Override
+    public V putFirst(K k, V v) {
+      return originalMap.putLast(k, v);
+    }
+
+    @Override
+    public V putLast(K k, V v) {
+      return originalMap.putFirst(k, v);
+    }
+
+    @Override
+    public int size() {
+      return originalMap.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return originalMap.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return originalMap.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(Object value) {
+      return originalMap.containsValue(value);
+    }
+
+    @Override
+    public V get(Object key) {
+      return originalMap.get(key);
+    }
+
+    @Override
+    public V put(K key, V value) {
+      return originalMap.putFirst(key, value);
+    }
+
+    @Override
+    public V remove(Object key) {
+      return originalMap.remove(key);
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m) {
+      Objects.requireNonNull(m);
+      for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
+        this.put(e.getKey(), e.getValue());
+      }
+    }
+
+    @Override
+    public void clear() {
+      originalMap.clear();
+    }
+
+    @Override
+    public Set<K> keySet() {
+      return originalMap.keySet().reversed();
+    }
+
+    @Override
+    public Collection<V> values() {
+      return originalMap.values().reversed();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+      return originalMap.entrySet().reversed();
+    }
+
+    @Override
+    public boolean remove(Object key, Object value) {
+      return originalMap.remove(key, value);
+    }
+
+    @Override
+    public int hashCode() {
+      return originalMap.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == this) return true;
+      if (!(obj instanceof Map<?, ?>)) return false;
+      return originalMap.equals(obj);
+    }
+  }
+
+  private class ValuesView extends AbstractCollection<V> implements SequencedCollection<V> {
+    private ReversedValuesView reversedValuesView = null;
+
+    @Override
+    public Iterator<V> iterator() {
+      return new LinkedIterator<>(CustomLinkedHashMap.this.firstNode, true, Node::getValue);
+    }
+
+    @Override
+    public int size() {
+      return CustomLinkedHashMap.this.size();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return CustomLinkedHashMap.this.containsValue(o);
+    }
+
+    @Override
+    public void clear() {
+      CustomLinkedHashMap.this.clear();
+    }
+
+    @Override
+    public SequencedCollection<V> reversed() {
+      if (reversedValuesView == null) {
+        reversedValuesView = new ReversedValuesView();
+      }
+      return reversedValuesView;
+    }
+
+    @Override
+    public V getFirst() {
+      return getElementFromSequencedNode(firstNode, Node::getValue, MAP_IS_EMPTY_GET_FIRST_VALUE);
+    }
+
+    @Override
+    public V getLast() {
+      return getElementFromSequencedNode(lastNode, Node::getValue, MAP_IS_EMPTY_GET_LAST_VALUE);
+    }
+
+    private class ReversedValuesView extends AbstractCollection<V>
+        implements SequencedCollection<V> {
+      @Override
+      public Iterator<V> iterator() {
+        return new LinkedIterator<>(CustomLinkedHashMap.this.lastNode, false, Node::getValue);
+      }
+
+      @Override
+      public int size() {
+        return CustomLinkedHashMap.this.size();
+      }
+
+      @Override
+      public SequencedCollection<V> reversed() {
+        return ValuesView.this;
+      }
+
+      @Override
+      public V getFirst() {
+        return getElementFromSequencedNode(
+            CustomLinkedHashMap.this.lastNode, Node::getValue, MAP_IS_EMPTY_GET_FIRST_VALUE);
+      }
+
+      @Override
+      public V getLast() {
+        return getElementFromSequencedNode(
+            CustomLinkedHashMap.this.firstNode, Node::getValue, MAP_IS_EMPTY_GET_LAST_VALUE);
+      }
+    }
+  }
+
+  private final class KeySetView extends AbstractSet<K> implements SequencedSet<K> {
+    public static final String MAP_IS_EMPTY_GET_LAST_KEY = "Map is empty (getLast key)";
+    ReversedKeySetView reversedKeySetView = null;
+
+    @Override
+    public Iterator<K> iterator() {
+      return new LinkedIterator<>(CustomLinkedHashMap.this.firstNode, true, Node::getKey);
+    }
+
+    @Override
+    public int size() {
+      return CustomLinkedHashMap.this.size();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return CustomLinkedHashMap.this.containsKey(o);
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      final boolean contained = CustomLinkedHashMap.this.containsKey(o);
+      if (contained) {
+        CustomLinkedHashMap.this.remove(o);
+      }
+      return contained;
+    }
+
+    @Override
+    public void clear() {
+      CustomLinkedHashMap.this.clear();
+    }
+
+    @Override
+    public SequencedSet<K> reversed() {
+      if (reversedKeySetView == null) {
+        reversedKeySetView = new ReversedKeySetView();
+      }
+      return reversedKeySetView;
+    }
+
+    @Override
+    public K getFirst() {
+      return getElementFromSequencedNode(
+          CustomLinkedHashMap.this.firstNode, Node::getKey, MAP_IS_EMPTY_GET_FIRST_KEY);
+    }
+
+    @Override
+    public K getLast() {
+      return getElementFromSequencedNode(
+          CustomLinkedHashMap.this.lastNode, Node::getKey, MAP_IS_EMPTY_GET_LAST_KEY);
+    }
+
+    @Override
+    public int hashCode() {
+      return super.hashCode();
+    }
+
+    private final class ReversedKeySetView extends AbstractSet<K> implements SequencedSet<K> {
+      @Override
+      public Iterator<K> iterator() {
+        return new LinkedIterator<>(CustomLinkedHashMap.this.lastNode, false, Node::getKey);
+      }
+
+      @Override
+      public int size() {
+        return CustomLinkedHashMap.this.size();
+      }
+
+      @Override
+      public boolean contains(Object o) {
+        return CustomLinkedHashMap.this.containsKey(o);
+      }
+
+      @Override
+      public boolean remove(Object o) {
+        final boolean contains = CustomLinkedHashMap.this.containsKey(o);
+        if (contains) {
+          CustomLinkedHashMap.this.remove(o);
+        }
+        return contains;
+      }
+
+      @Override
+      public void clear() {
+        CustomLinkedHashMap.this.clear();
+      }
+
+      @Override
+      public SequencedSet<K> reversed() {
+        return CustomLinkedHashMap.this.keySet();
+      }
+
+      @Override
+      public K getFirst() {
+        return getElementFromSequencedNode(
+            CustomLinkedHashMap.this.lastNode, Node::getKey, MAP_IS_EMPTY_GET_FIRST_KEY);
+      }
+
+      @Override
+      public K getLast() {
+        return getElementFromSequencedNode(
+            CustomLinkedHashMap.this.firstNode, Node::getKey, MAP_IS_EMPTY_GET_LAST_KEY);
+      }
+    }
+  }
+
+  private class EntrySetView extends AbstractSet<Map.Entry<K, V>>
+      implements SequencedSet<Map.Entry<K, V>> {
+    private ReversedEntrySetView reversedEntrySetView = null;
+
+    @Override
+    public Iterator<Map.Entry<K, V>> iterator() {
+      return new LinkedIterator<>(
+          CustomLinkedHashMap.this.firstNode, true, Node::getImmutableEntry);
+    }
+
+    @Override
+    public int size() {
+      return CustomLinkedHashMap.this.size();
+    }
+
+    @Override
+    public boolean contains(Object o) {
+      return containsEntry(o);
+    }
+
+    private boolean containsEntry(Object o) {
+      if (!(o instanceof Map.Entry<?, ?>)) {
+        return false;
+      }
+      Object key = ((Entry<?, ?>) o).getKey();
+      Node<K, V> node = CustomLinkedHashMap.this.hashMap.get(key);
+      return node != null && Objects.equals(node.getValue(), ((Entry<?, ?>) o).getValue());
+    }
+
+    @Override
+    public boolean remove(Object o) {
+      return removeEntry(o);
+    }
+
+    private boolean removeEntry(Object o) {
+      if (!(o instanceof Map.Entry<?, ?> entry)) {
+        return false;
+      }
+      Object key = entry.getKey();
+      Node<K, V> node = CustomLinkedHashMap.this.hashMap.get(key);
+
+      if (node != null && Objects.equals(node.getValue(), entry.getValue())) {
+        CustomLinkedHashMap.this.remove(key);
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    public void clear() {
+      CustomLinkedHashMap.this.clear();
+    }
+
+    @Override
+    public SequencedSet<Map.Entry<K, V>> reversed() {
+      if (reversedEntrySetView == null) {
+        reversedEntrySetView = new ReversedEntrySetView();
+      }
+      return reversedEntrySetView;
+    }
+
+    @Override
+    public Map.Entry<K, V> getFirst() {
+      return getElementFromSequencedNode(
+          CustomLinkedHashMap.this.firstNode,
+          Node::getImmutableEntry,
+          "Map is empty (getFirst entry)");
+    }
+
+    @Override
+    public Map.Entry<K, V> getLast() {
+      return getElementFromSequencedNode(
+          CustomLinkedHashMap.this.lastNode,
+          Node::getImmutableEntry,
+          "Map is empty (getLast entry)");
+    }
+
+    private final class ReversedEntrySetView extends AbstractSet<Map.Entry<K, V>>
+        implements SequencedSet<Map.Entry<K, V>> {
+
+      @Override
+      public Iterator<Entry<K, V>> iterator() {
+        return new LinkedIterator<>(
+            CustomLinkedHashMap.this.lastNode, false, Node::getImmutableEntry);
+      }
+
+      @Override
+      public int size() {
+        return CustomLinkedHashMap.this.size();
+      }
+
+      @Override
+      public boolean contains(Object o) {
+        return containsEntry(o);
+      }
+
+      @Override
+      public boolean remove(Object o) {
+        return removeEntry(o);
+      }
+
+      @Override
+      public void clear() {
+        CustomLinkedHashMap.this.clear();
+      }
+
+      @Override
+      public SequencedSet<Entry<K, V>> reversed() {
+        return CustomLinkedHashMap.this.entrySet();
+      }
+
+      @Override
+      public Entry<K, V> getFirst() {
+        return getElementFromSequencedNode(
+            CustomLinkedHashMap.this.lastNode,
+            Node::getImmutableEntry,
+            "Map is empty (getFirst entry)");
+      }
+
+      @Override
+      public Entry<K, V> getLast() {
+        return getElementFromSequencedNode(
+            CustomLinkedHashMap.this.firstNode,
+            Node::getImmutableEntry,
+            "Map is empty (getLast entry)");
+      }
+    }
+  }
+
+  private class LinkedIterator<T> implements Iterator<T> {
+    private final boolean forward;
+    private final java.util.function.Function<Node<K, V>, T> elementExtractor;
+    private Node<K, V> nextNode;
+    private Node<K, V> lastReturnedNode;
+
+    LinkedIterator(
+        Node<K, V> startNode,
+        boolean forward,
+        java.util.function.Function<Node<K, V>, T> elementExtractor) {
+      this.nextNode = startNode;
+      this.forward = forward;
+      this.elementExtractor = elementExtractor;
+      this.lastReturnedNode = null;
+    }
+
+    @Override
+    public final boolean hasNext() {
+      return nextNode != null;
+    }
+
+    @Override
+    public final T next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException("No more elements");
+      }
+      lastReturnedNode = nextNode;
+      T element = elementExtractor.apply(nextNode);
+      nextNode = forward ? nextNode.getNext() : nextNode.getPrevious();
+      return element;
+    }
+
+    @Override
+    public final void remove() {
+      if (lastReturnedNode == null) {
+        throw new IllegalStateException(
+            "next() must be called before remove(), or remove() called twice");
+      }
+      CustomLinkedHashMap.this.remove(lastReturnedNode.getKey());
+      lastReturnedNode = null;
+    }
+  }
+}

--- a/src/main/java/com/tasktracker/task/manager/HistoryManager.java
+++ b/src/main/java/com/tasktracker/task/manager/HistoryManager.java
@@ -4,6 +4,7 @@ import com.tasktracker.task.model.implementations.Task;
 import com.tasktracker.task.model.implementations.TaskView;
 import com.tasktracker.task.store.HistoryRepository;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * The {@code HistoryManager} interface provides mechanisms for managing a history of tasks. It
@@ -28,5 +29,14 @@ public interface HistoryManager {
    * @return {@code true} if the task was successfully added, otherwise {@code false}
    * @throws NullPointerException if the provided task is {@code null}
    */
-  boolean add(final Task task);
+  Optional<TaskView> put(final Task task);
+
+  /**
+   * Removes the task view associated with the specified task ID from the history repository.
+   *
+   * @param id the ID of the task to be removed
+   * @return an {@link Optional} containing the removed {@link TaskView} if it existed; otherwise,
+   *     an empty {@link Optional}
+   */
+  Optional<TaskView> remove(int id);
 }

--- a/src/main/java/com/tasktracker/task/manager/InMemoryHistoryManager.java
+++ b/src/main/java/com/tasktracker/task/manager/InMemoryHistoryManager.java
@@ -6,44 +6,27 @@ import com.tasktracker.task.store.HistoryRepository;
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 
 /**
- * A manager that handles the history of tasks in memory with a defined limit. This implementation
- * interacts with a {@link HistoryRepository} to store and manage the task history. It ensures the
- * history does not exceed a specified maximum length.
+ * A manager implementation that handles task history in memory. It uses a {@link HistoryRepository}
+ * for storing and managing task views, ensuring efficient history management.
  */
 public class InMemoryHistoryManager implements HistoryManager {
   private final HistoryRepository historyStore;
-  private final int historyLengthLimit;
 
   /**
-   * Creates an instance of {@code InMemoryHistoryManager} to manage task history.
+   * Constructs an {@code InMemoryHistoryManager} with the specified {@link HistoryRepository}.
+   * Ensures the provided history repository is not null.
    *
-   * @param historyStore the repository for storing task history; must not be {@code null}
-   * @param historyLengthLimit the maximum number of tasks allowed in the history; must be at least
-   *     1
+   * @param historyStore the {@link HistoryRepository} used for managing the task history; must not
+   *     be {@code null}
    * @throws NullPointerException if {@code historyStore} is {@code null}
-   * @throws IllegalArgumentException if {@code historyLengthLimit} is less than 1
    */
-  public InMemoryHistoryManager(final HistoryRepository historyStore, final int historyLengthLimit)
+  public InMemoryHistoryManager(final HistoryRepository historyStore)
       throws NullPointerException, IllegalArgumentException {
     Objects.requireNonNull(historyStore, "History Repository can't be null");
     this.historyStore = historyStore;
-    this.historyLengthLimit = getValidatedHistoryLimit(historyLengthLimit);
-  }
-
-  /**
-   * Validates the provided history length limit to ensure it is greater than or equal to 1.
-   *
-   * @param historyLengthLimit the maximum number of tasks allowed in the history
-   * @return the validated history length limit
-   * @throws IllegalArgumentException if the provided limit is less than 1
-   */
-  private int getValidatedHistoryLimit(int historyLengthLimit) {
-    if (historyLengthLimit < 1) {
-      throw new IllegalArgumentException("History length limit must be at least 1.");
-    }
-    return historyLengthLimit;
   }
 
   /**
@@ -58,20 +41,30 @@ public class InMemoryHistoryManager implements HistoryManager {
   }
 
   /**
-   * Adds a task to the history. If the history reaches its maximum allowed size, the oldest task is
-   * removed to make room for the new task. The task is saved in the history as a {@link TaskView}
-   * object with the current timestamp.
+   * Adds the provided task to the history as a {@link TaskView}. The task's view is saved with the
+   * current timestamp. If a task with the same ID already exists in the history, it will be
+   * replaced.
    *
-   * @param task the task to add to the history, must not be {@code null}
-   * @return {@code true} if the task was successfully added, otherwise {@code false}
-   * @throws NullPointerException if the provided task is {@code null}
+   * @param task the task to be added to the history, must not be {@code null}
+   * @return an {@link Optional} containing the previous {@link TaskView}, if a task with the same
+   *     ID was replaced; otherwise, an empty {@link Optional}
+   * @throws NullPointerException if the provided {@code task} is {@code null}
    */
   @Override
-  public boolean add(final Task task) throws NullPointerException {
+  public Optional<TaskView> put(final Task task) throws NullPointerException {
     Objects.requireNonNull(task, "Task can't be null.");
-    if (historyStore.size() == historyLengthLimit) {
-      historyStore.pollFirst();
-    }
-    return historyStore.add(new TaskView(task.getId(), LocalDateTime.now()));
+    return historyStore.put(new TaskView(task.getId(), LocalDateTime.now()));
+  }
+
+  /**
+   * Removes the task view associated with the specified task ID from the history repository.
+   *
+   * @param id the ID of the task to be removed
+   * @return an {@link Optional} containing the removed {@link TaskView} if it existed; otherwise,
+   *     an empty {@link Optional}
+   */
+  @Override
+  public Optional<TaskView> remove(int id) {
+    return historyStore.remove(id);
   }
 }

--- a/src/main/java/com/tasktracker/task/manager/InMemoryHistoryManager.java
+++ b/src/main/java/com/tasktracker/task/manager/InMemoryHistoryManager.java
@@ -4,9 +4,7 @@ import com.tasktracker.task.model.implementations.Task;
 import com.tasktracker.task.model.implementations.TaskView;
 import com.tasktracker.task.store.HistoryRepository;
 import java.time.LocalDateTime;
-import java.util.Collection;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * A manager implementation that handles task history in memory. It uses a {@link HistoryRepository}

--- a/src/main/java/com/tasktracker/task/manager/TaskManager.java
+++ b/src/main/java/com/tasktracker/task/manager/TaskManager.java
@@ -55,7 +55,7 @@ public interface TaskManager {
    * @return an {@link Optional} containing the com.tasktracker.task if it exists, or an empty
    *     Optional if not
    */
-  Optional<Task> getTaskById(int id);
+  Optional<Task> getTask(int id);
 
   /**
    * Creates and adds a new Regular Task to the repository.

--- a/src/main/java/com/tasktracker/task/model/implementations/TaskView.java
+++ b/src/main/java/com/tasktracker/task/model/implementations/TaskView.java
@@ -2,41 +2,30 @@ package com.tasktracker.task.model.implementations;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
-import java.util.UUID;
 
 /**
- * Represents a view of a specific task, containing details such as the view's unique ID, the
- * timestamp when the view was created, and the ID of the associated task.
+ * Represents a view of a specific task, containing details such as the ID of the associated task
+ * and the timestamp when the view was created.
  */
 public final class TaskView implements Comparable<TaskView> {
-  private final UUID viewId;
   private final int taskId;
   private final LocalDateTime viewDateTime;
 
   /**
-   * Creates a new {@code TaskView} instance with a unique identifier and the current timestamp.
+   * Creates a new {@code TaskView} instance with the specified task ID and timestamp.
    *
    * @param taskId the ID of the task being viewed
+   * @param viewDateTime the timestamp when the task view was created
    */
   public TaskView(int taskId, LocalDateTime viewDateTime) {
-    this.viewId = UUID.randomUUID();
     this.viewDateTime = viewDateTime;
     this.taskId = taskId;
   }
 
   /**
-   * Retrieves the unique identifier for this task view.
-   *
-   * @return the unique ID of the task view
-   */
-  public UUID getViewId() {
-    return viewId;
-  }
-
-  /**
    * Retrieves the timestamp indicating when this task view was created.
    *
-   * @return the creation time of the task view
+   * @return the timestamp when this task view was created
    */
   public LocalDateTime getViewDateTime() {
     return viewDateTime;
@@ -54,59 +43,49 @@ public final class TaskView implements Comparable<TaskView> {
   /**
    * Compares the specified object with this {@code TaskView} for equality.
    *
-   * @param object the object to be compared for equality with this task view
-   * @return {@code true} if the specified object is equal to this task view; {@code false}
-   *     otherwise
+   * @param object the object to be compared for equality with this {@code TaskView}
+   * @return {@code true} if the specified object is a {@code TaskView} with the same task ID as
+   *     this {@code TaskView}; {@code false} otherwise
    */
   @Override
   public boolean equals(Object object) {
     if (object == null || getClass() != object.getClass()) return false;
     TaskView taskView = (TaskView) object;
-    return taskId == taskView.taskId
-        && Objects.equals(this.viewDateTime, taskView.getViewDateTime())
-        && Objects.equals(this.viewId, taskView.getViewId());
+    return taskId == taskView.taskId;
   }
 
   /**
-   * Returns the hash code value for this {@code TaskView}.
+   * Returns the hash code value for this {@code TaskView}. The hash code is computed based on the
+   * task ID.
    *
-   * @return the hash code value for this task view
+   * @return the hash code value for this {@code TaskView}
    */
   @Override
   public int hashCode() {
-    return Objects.hash(viewId, taskId, viewDateTime);
+    return Objects.hash(taskId);
   }
 
   /**
    * Returns a string representation of this {@code TaskView}.
    *
-   * @return a string representation of this task view
+   * @return a string representation of this {@code TaskView} in the format:
+   *     TaskView{taskId=<taskId>, viewDateTime=<viewDateTime>}
    */
   @Override
   public String toString() {
-    return "TaskView{" + "viewDateTime=" + viewDateTime + ", taskId=" + taskId + '}';
+    return "TaskView{" + "taskId=" + taskId + ", viewDateTime=" + viewDateTime + '}';
   }
 
   /**
-   * Compares this {@code TaskView} instance with another {@code TaskView} for ordering based on the
-   * view creation timestamp, task ID, and unique view ID.
+   * Compares this {@code TaskView} instance with another {@code TaskView} to determine their
+   * relative order. The comparison is based on the task ID.
    *
    * @param other the {@code TaskView} to compare with this instance
-   * @return a negative integer, zero, or a positive integer as this {@code TaskView}'s creation
-   *     timestamp is earlier than, equal to, or later than the specified {@code TaskView}'s
-   *     creation timestamp. If timestamps are equal, compares by task ID, and if task IDs are also
-   *     equal, compares by view ID.
+   * @return a negative integer, zero, or a positive integer as this {@code TaskView}'s task ID is
+   *     less than, equal to, or greater than the specified {@code TaskView}'s task ID
    */
   @Override
   public int compareTo(TaskView other) {
-    int cmp = this.viewDateTime.compareTo(other.viewDateTime);
-    if (cmp != 0) {
-      return cmp;
-    }
-    cmp = Integer.compare(this.taskId, other.getTaskId());
-    if (cmp != 0) {
-      return cmp;
-    }
-    return this.viewId.compareTo(other.viewId);
+    return Integer.compare(this.taskId, other.getTaskId());
   }
 }

--- a/src/main/java/com/tasktracker/task/store/HistoryRepository.java
+++ b/src/main/java/com/tasktracker/task/store/HistoryRepository.java
@@ -10,35 +10,23 @@ import java.util.Optional;
  */
 public interface HistoryRepository {
   /**
-   * Adds a new task view to the history repository. If the task view is already present, it will
-   * not be added again.
+   * Adds a new task view to the history repository, replacing any existing task view with the same
+   * ID.
    *
-   * @param taskView the task view to be added to the repository
-   * @return {@code true} if the task view was successfully added, {@code false} if it was already
-   *     present
+   * @param taskView the task view to be added to the repository; must not be {@code null}
+   * @return an {@link Optional} containing the previous {@link TaskView} if one was replaced, or an
+   *     empty {@link Optional} if no task view with the same ID existed
    * @throws NullPointerException if the provided {@code taskView} is {@code null}
    */
-  boolean add(TaskView taskView);
+  Optional<TaskView> put(TaskView taskView);
 
   /**
-   * Retrieves all tasks stored in the history repository.
+   * Retrieves all task views stored in the history repository as a collection of map entries. Each
+   * entry consists of the task ID as the key and its corresponding {@link TaskView} as the value.
    *
-   * @return a collection containing all tasks in the repository
+   * @return an unmodifiable collection of map entries containing all task views in the repository
    */
   Collection<TaskView> getAll();
 
-  /**
-   * Returns the number of tasks currently stored in the repository.
-   *
-   * @return the size of the repository
-   */
-  int size();
-
-  /**
-   * Removes and returns the first task from the history repository, if present.
-   *
-   * @return an {@code Optional} containing the first task if it exists, or an empty {@code
-   *     Optional} if the repository is empty
-   */
-  Optional<TaskView> pollFirst();
+  Optional<TaskView> remove(int id);
 }

--- a/src/main/java/com/tasktracker/task/store/InMemoryHistoryRepository.java
+++ b/src/main/java/com/tasktracker/task/store/InMemoryHistoryRepository.java
@@ -8,49 +8,45 @@ import java.util.*;
  * stored in a navigable, ordered collection to maintain a defined order.
  */
 public class InMemoryHistoryRepository implements HistoryRepository {
-  private final LinkedList<TaskView> store = new LinkedList<>();
+  private static final int INITIAL_CAPACITY = 16;
+  private static final float LOAD_FACTOR = 0.75f;
+  private final LinkedHashMap<Integer, TaskView> store =
+      new LinkedHashMap<>(INITIAL_CAPACITY, LOAD_FACTOR, true);
 
   /**
-   * Adds a new task view to the history repository. If the task view is already present, it will
-   * not be added again.
+   * Adds a new task view to the history repository, replacing any existing task view with the same
+   * ID.
    *
    * @param taskView the task view to be added to the repository
-   * @return {@code true} if the task view was successfully added, {@code false} if it was already
-   *     present
+   * @return an {@link Optional} containing the previous {@link TaskView} if one was replaced, or an
+   *     empty {@link Optional} if no task view with the same ID existed
    * @throws NullPointerException if the provided {@code taskView} is {@code null}
    */
   @Override
-  public boolean add(final TaskView taskView) {
-    return store.add(taskView);
+  public Optional<TaskView> put(final TaskView taskView) {
+    return Optional.ofNullable(store.put(taskView.getTaskId(), taskView));
   }
 
   /**
-   * Retrieves all tasks stored in the history repository.
+   * Retrieves all task views stored in the history repository as a collection of map entries. Each
+   * entry consists of the task ID as the key and its corresponding {@link TaskView} as the value.
    *
-   * @return an unmodifiable collection of all tasks in the repository
+   * @return an unmodifiable collection of map entries containing all task views in the repository
    */
   @Override
   public Collection<TaskView> getAll() {
-    return Collections.unmodifiableCollection(store);
+    return Collections.unmodifiableCollection(store.values());
   }
 
   /**
-   * Returns the number of tasks currently in the history repository.
+   * Removes a task view from the history repository by its ID, if it exists.
    *
-   * @return the size of the task repository
+   * @param id the ID of the task view to be removed
+   * @return an {@link Optional} containing the removed {@link TaskView} if found, or an empty
+   *     {@link Optional} if no task view with the given ID exists
    */
   @Override
-  public int size() {
-    return store.size();
-  }
-
-  /**
-   * Removes and returns the first task in the history repository if it exists.
-   *
-   * @return an {@code Optional} containing the first task if present, otherwise an empty {@code
-   *     Optional}
-   */
-  public Optional<TaskView> pollFirst() {
-    return Optional.ofNullable(store.pollFirst());
+  public Optional<TaskView> remove(int id) {
+    return Optional.ofNullable(store.remove(id));
   }
 }

--- a/src/main/java/com/tasktracker/task/store/InMemoryHistoryRepository.java
+++ b/src/main/java/com/tasktracker/task/store/InMemoryHistoryRepository.java
@@ -1,5 +1,6 @@
 package com.tasktracker.task.store;
 
+import com.tasktracker.collections.CustomLinkedHashMap;
 import com.tasktracker.task.model.implementations.TaskView;
 import java.util.*;
 
@@ -10,8 +11,7 @@ import java.util.*;
 public class InMemoryHistoryRepository implements HistoryRepository {
   private static final int INITIAL_CAPACITY = 16;
   private static final float LOAD_FACTOR = 0.75f;
-  private final LinkedHashMap<Integer, TaskView> store =
-      new LinkedHashMap<>(INITIAL_CAPACITY, LOAD_FACTOR, true);
+  private final CustomLinkedHashMap<Integer, TaskView> store = new CustomLinkedHashMap<>();
 
   /**
    * Adds a new task view to the history repository, replacing any existing task view with the same

--- a/src/main/java/com/tasktracker/task/store/InMemoryTaskRepository.java
+++ b/src/main/java/com/tasktracker/task/store/InMemoryTaskRepository.java
@@ -76,7 +76,7 @@ public final class InMemoryTaskRepository implements TaskRepository {
    *     Optional} if no com.tasktracker.task was found for the given ID
    * @throws IllegalArgumentException if no com.tasktracker.task exists for the specified ID
    */
-  public Optional<Task> removeTaskById(final int id) {
+  public Optional<Task> removeTask(final int id) {
     checkTaskExists(id);
     return Optional.ofNullable(store.remove(id));
   }

--- a/src/main/java/com/tasktracker/task/store/TaskRepository.java
+++ b/src/main/java/com/tasktracker/task/store/TaskRepository.java
@@ -59,7 +59,7 @@ public interface TaskRepository {
    *     Optional} if no com.tasktracker.task was found for the given ID
    * @throws IllegalArgumentException if no com.tasktracker.task exists for the specified ID
    */
-  Optional<Task> removeTaskById(int id);
+  Optional<Task> removeTask(int id);
 
   /**
    * Finds tasks that match the given {@link Predicate} criteria.

--- a/src/main/java/com/tasktracker/util/Managers.java
+++ b/src/main/java/com/tasktracker/util/Managers.java
@@ -18,17 +18,17 @@ public class Managers {
   private Managers() {}
 
   /**
-   * Creates and returns the default {@link TaskManager} instance with an in-memory task and history
-   * storage. The history is managed using an {@link InMemoryHistoryManager} with a predefined
-   * limit.
+   * Creates and returns the default implementation of {@link TaskManager}. This default instance
+   * uses in-memory repositories for task and history management, and is linked to an in-memory
+   * history manager for handling task history.
    *
-   * @return the default {@link TaskManager} instance
+   * @return an instance of {@link InMemoryTaskManager} configured with in-memory task and history
+   *     repositories
    */
   public static TaskManager getDefault() {
     TaskRepository taskRepository = new InMemoryTaskRepository();
     HistoryRepository historyRepository = new InMemoryHistoryRepository();
-    int historyLimit = 10;
-    HistoryManager historyManager = new InMemoryHistoryManager(historyRepository, historyLimit);
+    HistoryManager historyManager = new InMemoryHistoryManager(historyRepository);
     return new InMemoryTaskManager(taskRepository, historyManager);
   }
 }

--- a/src/test/java/com/tasktracker/collections/CustomLinkedHashMapTest.java
+++ b/src/test/java/com/tasktracker/collections/CustomLinkedHashMapTest.java
@@ -1,0 +1,1601 @@
+package com.tasktracker.collections; // Убедись, что пакет правильный
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+import org.junit.jupiter.api.*;
+
+/** Comprehensive tests for the CustomLinkedHashMap class. */
+class CustomLinkedHashMapTest {
+
+  private static final Integer K1 = 1;
+  private static final Integer K2 = 2;
+  private static final Integer K3 = 3;
+  private static final Integer K4 = 4;
+  private static final String V1 = "Value 1";
+  private static final String V2 = "Value 2";
+  private static final String V3 = "Value 3";
+  private static final String V4 = "Value 4";
+  private static final String V_REPLACE = "Replaced Value";
+  private static final Integer K_NON_EXIST = 999;
+  private static final String V_NON_EXIST = "NonExistentValue";
+  private CustomLinkedHashMap<Integer, String> map;
+  private CustomLinkedHashMap<Integer, String> mapEmpty;
+  private CustomLinkedHashMap<Integer, String> mapSingleElement;
+
+  @BeforeEach
+  void setUp() {
+    mapEmpty = new CustomLinkedHashMap<>();
+    map = new CustomLinkedHashMap<>();
+    map.put(K1, V1);
+    map.put(K2, V2);
+    map.put(K3, V3);
+    // mapStringKeys = new CustomLinkedHashMap<>(); // Не используется
+    mapSingleElement = new CustomLinkedHashMap<>();
+    mapSingleElement.put(K1, V1);
+  }
+
+  // =====================================================
+  // Basic Map Operations Tests
+  // =====================================================
+
+  // Generic test for basic view properties
+  private <T> void testViewBasics(
+      Collection<T> view, T existingElement, T nonExistingElement, int expectedSize) {
+    assertNotNull(view, "View should not be null");
+    assertEquals(expectedSize, view.size(), "View size should match map size");
+    assertEquals(map.isEmpty(), view.isEmpty(), "View isEmpty should match map isEmpty");
+
+    // Contains checks
+    if (existingElement != null) {
+      assertTrue(
+          view.contains(existingElement),
+          "View should contain existing element: " + existingElement);
+    }
+    if (nonExistingElement != null) {
+      assertFalse(
+          view.contains(nonExistingElement),
+          "View should not contain non-existing element: " + nonExistingElement);
+    }
+
+    // Test clear via view
+    if (!view.isEmpty()) {
+      // Create a temporary map to test clear on, preserving 'map' for other tests if needed
+      CustomLinkedHashMap<Integer, String> tempMap = createCopy(map);
+      Collection<T> tempView = getViewForMap(tempMap, view.getClass());
+
+      assertFalse(tempMap.isEmpty());
+      assertFalse(tempView.isEmpty());
+      tempView.clear();
+      assertTrue(tempMap.isEmpty(), "Map should be empty after clearing view");
+      assertTrue(tempView.isEmpty(), "View should be empty after clearing view");
+      assertEquals(0, tempView.size(), "View size should be 0 after clearing");
+    } else {
+      view.clear();
+      assertTrue(view.isEmpty());
+      assertEquals(0, view.size());
+    }
+  }
+
+  // Generic test for view's remove(Object o) method
+  private <T> void testViewRemove(
+      Collection<T> view, T elementToRemove, Object keyToRemove, int initialSize) {
+    assertTrue(
+        view.remove(elementToRemove),
+        "Removing existing element via view should return true. Element: " + elementToRemove);
+    assertEquals(initialSize - 1, map.size(), "Map size should decrease after view remove");
+    assertEquals(initialSize - 1, view.size(), "View size should decrease after view remove");
+    assertFalse(map.containsKey(keyToRemove), "Element should be removed from map");
+    assertFalse(view.contains(elementToRemove), "Element should be removed from view");
+
+    assertFalse(
+        view.remove(nonExistingElementForView(view)),
+        "Removing non-existing element via view should return false");
+    assertEquals(
+        initialSize - 1, map.size(), "Map size should not change after removing non-existing");
+  }
+
+  // =====================================================
+  // View Tests (Common Logic & Placeholders)
+  // =====================================================
+
+  // Generic test for iterator's remove() method
+  private <T> void testIteratorRemove(
+      Collection<T> view, Object keyToRemove, T elementToRemove, int initialSize) {
+    Iterator<T> iterator = view.iterator();
+    T foundElement = null;
+    while (iterator.hasNext()) {
+      T current = iterator.next();
+      if (Objects.equals(current, elementToRemove)) {
+        foundElement = current;
+        iterator.remove();
+        break;
+      }
+    }
+    assertNotNull(foundElement, "Element to remove was not found via iterator");
+
+    assertEquals(initialSize - 1, map.size(), "Map size should decrease after iterator remove");
+    assertEquals(initialSize - 1, view.size(), "View size should decrease after iterator remove");
+    assertFalse(map.containsKey(keyToRemove), "Element should be removed from map (key check)");
+    assertFalse(view.contains(elementToRemove), "Element should be removed from view");
+
+    // Test IllegalStateException after remove
+    Iterator<T> finalIterator = iterator; // Need final variable for lambda
+    assertThrows(
+        IllegalStateException.class,
+        finalIterator::remove,
+        "Calling remove() again should throw IllegalStateException");
+
+    // Test IllegalStateException before next
+    iterator = view.iterator(); // New iterator
+    Iterator<T> finalIteratorBeforeNext = iterator;
+    assertThrows(
+        IllegalStateException.class,
+        finalIteratorBeforeNext::remove,
+        "Calling remove() before next() should throw IllegalStateException");
+  }
+
+  // Helper to get a non-existing element of the correct type for a view
+  private <T> T nonExistingElementForView(Collection<T> view) {
+    if (view instanceof Set) {
+      if (view.isEmpty() || view.iterator().next() instanceof Integer) {
+        return (T) K_NON_EXIST;
+      } else if (view.iterator().next() instanceof String) {
+        return (T) V_NON_EXIST;
+      } else if (view.iterator().next() instanceof Map.Entry) {
+        return (T) new AbstractMap.SimpleImmutableEntry<>(K_NON_EXIST, V_NON_EXIST);
+      }
+    } else if (view instanceof Collection) {
+      return (T) V_NON_EXIST;
+    }
+    throw new IllegalArgumentException("Unsupported view type for nonExistingElementForView");
+  }
+
+  // Helper to get the correct view type from a map instance
+  private <T> Collection<T> getViewForMap(
+      CustomLinkedHashMap<Integer, String> targetMap, Class<?> viewClass) {
+    if (viewClass.getName().contains("KeySetView")) {
+      return (Collection<T>) targetMap.keySet();
+    } else if (viewClass.getName().contains("ValuesView")) {
+      return (Collection<T>) targetMap.values();
+    } else if (viewClass.getName().contains("EntrySetView")) {
+      return (Collection<T>) targetMap.entrySet();
+    }
+    throw new IllegalArgumentException("Unsupported view class: " + viewClass);
+  }
+
+  // Helper to create a copy of the map for destructive tests
+  private CustomLinkedHashMap<Integer, String> createCopy(
+      CustomLinkedHashMap<Integer, String> source) {
+    CustomLinkedHashMap<Integer, String> copy = new CustomLinkedHashMap<>();
+    copy.putAll(source);
+    return copy;
+  }
+
+  /**
+   * Asserts that iterating over the map's entrySet yields the expected keys and values in order.
+   * Also checks keySet, values, and direct iterator.
+   */
+  private void assertIterationOrder(
+      CustomLinkedHashMap<Integer, String> mapToTest,
+      List<Integer> expectedKeys,
+      List<String> expectedValues) {
+    assertIterationOrderSpecific(
+        mapToTest.keySet(), expectedKeys, "KeySet iteration order mismatch");
+    assertIterationOrderSpecific(
+        mapToTest.values(), expectedValues, "Values iteration order mismatch");
+
+    List<Map.Entry<Integer, String>> expectedEntries = new ArrayList<>();
+    for (int i = 0; i < expectedKeys.size(); i++) {
+      expectedEntries.add(
+          new AbstractMap.SimpleImmutableEntry<>(expectedKeys.get(i), expectedValues.get(i)));
+    }
+    assertIterationOrderSpecific(
+        mapToTest.entrySet(), expectedEntries, "EntrySet iteration order mismatch");
+
+    // Also check direct iterator (values)
+    List<String> directIteratorValues = new ArrayList<>();
+    mapToTest.iterator().forEachRemaining(directIteratorValues::add);
+    assertIterableEquals(
+        expectedValues, directIteratorValues, "Direct iterator (values) order mismatch");
+  }
+
+  /** Asserts that iterating over a specific collection yields elements in the expected order. */
+  private <T> void assertIterationOrderSpecific(
+      Iterable<T> iterable, List<T> expectedOrder, String message) {
+    List<T> actualOrder = new ArrayList<>();
+    iterable.iterator().forEachRemaining(actualOrder::add);
+    assertIterableEquals(expectedOrder, actualOrder, message);
+  }
+
+  // Overload for simple assertion without custom message
+  private <T> void assertIterationOrderSpecific(Iterable<T> iterable, List<T> expectedOrder) {
+    assertIterationOrderSpecific(
+        iterable, expectedOrder, "Iteration order mismatch for the specific view/iterable");
+  }
+
+  @Nested
+  @DisplayName("Basic Map Operations")
+  class BasicOperations {
+
+    @Test
+    @DisplayName("put() should add new element and return null")
+    void put_AddNewElement_ShouldReturnNull() {
+      assertNull(map.put(K4, V4), "Putting a new key should return null");
+      assertEquals(4, map.size(), "Size should increase");
+      assertEquals(V4, map.get(K4), "New value should be retrievable");
+      assertEquals(K4, map.lastEntry().getKey(), "New element should be last");
+    }
+
+    @Test
+    @DisplayName("put() should replace existing element and return old value")
+    void put_ReplaceExistingElement_ShouldReturnOldValue() {
+      assertEquals(
+          V2, map.put(K2, V_REPLACE), "Putting an existing key should return the old value");
+      assertEquals(3, map.size(), "Size should remain the same");
+      assertEquals(V_REPLACE, map.get(K2), "Value should be updated");
+      // Verify order didn't change for the updated element
+      List<Integer> keys = new ArrayList<>(map.keySet());
+      assertEquals(List.of(K1, K2, K3), keys, "Order should be preserved on update");
+    }
+
+    @Test
+    @DisplayName("put() into empty map")
+    void put_IntoEmptyMap_ShouldWork() {
+      assertNull(mapEmpty.put(K1, V1));
+      assertEquals(1, mapEmpty.size());
+      assertEquals(V1, mapEmpty.get(K1));
+      assertEquals(K1, mapEmpty.firstEntry().getKey());
+      assertEquals(K1, mapEmpty.lastEntry().getKey());
+    }
+
+    @Test
+    @DisplayName("put() should throw NullPointerException for null key")
+    void put_NullKey_ShouldThrowNPE() {
+      assertThrows(
+          NullPointerException.class, () -> map.put(null, V1), "Null key should throw NPE");
+    }
+
+    @Test
+    @DisplayName("put() should throw NullPointerException for null value")
+    void put_NullValue_ShouldThrowNPE() {
+      assertThrows(
+          NullPointerException.class, () -> map.put(K4, null), "Null value should throw NPE");
+    }
+
+    @Test
+    @DisplayName("get() should return correct value for existing key")
+    void get_ExistingKey_ShouldReturnCorrectValue() {
+      assertEquals(V1, map.get(K1));
+      assertEquals(V2, map.get(K2));
+      assertEquals(V3, map.get(K3));
+    }
+
+    @Test
+    @DisplayName("get() should return null for non-existent key")
+    void get_NonExistentKey_ShouldReturnNull() {
+      assertNull(map.get(K_NON_EXIST));
+      assertNull(mapEmpty.get(K1));
+    }
+
+    @Test
+    @DisplayName("get() should throw NullPointerException for null key")
+    void get_NullKey_ShouldThrowNPE() {
+      assertThrows(NullPointerException.class, () -> map.get(null), "Null key should throw NPE");
+    }
+
+    @Test
+    @DisplayName("remove() should remove existing element and return its value")
+    void remove_ExistingKey_ShouldRemoveAndReturnOldValue() {
+      assertEquals(V2, map.remove(K2), "Remove should return the value of the removed key");
+      assertEquals(2, map.size(), "Size should decrease");
+      assertFalse(map.containsKey(K2), "Removed key should not be present");
+      assertNull(map.get(K2), "Getting removed key should return null");
+      // Check order after removing middle element
+      assertIterationOrder(map, List.of(K1, K3), List.of(V1, V3));
+      assertEquals(K1, map.firstEntry().getKey());
+      assertEquals(K3, map.lastEntry().getKey());
+    }
+
+    @Test
+    @DisplayName("remove() first element")
+    void remove_FirstElement_ShouldUpdateLinks() {
+      assertEquals(V1, map.remove(K1));
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K1));
+      assertEquals(K2, map.firstEntry().getKey());
+      assertEquals(V2, map.firstEntry().getValue());
+      assertEquals(K3, map.lastEntry().getKey());
+      assertIterationOrder(map, List.of(K2, K3), List.of(V2, V3));
+    }
+
+    @Test
+    @DisplayName("remove() last element")
+    void remove_LastElement_ShouldUpdateLinks() {
+      assertEquals(V3, map.remove(K3));
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K3));
+      assertEquals(K1, map.firstEntry().getKey());
+      assertEquals(K2, map.lastEntry().getKey());
+      assertEquals(V2, map.lastEntry().getValue());
+      assertIterationOrder(map, List.of(K1, K2), List.of(V1, V2));
+    }
+
+    @Test
+    @DisplayName("remove() only element")
+    void remove_OnlyElement_ShouldMakeMapEmpty() {
+      assertEquals(V1, mapSingleElement.remove(K1));
+      assertTrue(mapSingleElement.isEmpty());
+      assertEquals(0, mapSingleElement.size());
+      assertNull(mapSingleElement.firstEntry());
+      assertNull(mapSingleElement.lastEntry());
+      // Ensure caches are potentially cleared (test by getting views)
+      assertTrue(mapSingleElement.isEmpty());
+      assertTrue(mapSingleElement.isEmpty());
+      assertTrue(mapSingleElement.isEmpty());
+    }
+
+    @Test
+    @DisplayName("remove() should return null for non-existent key")
+    void remove_NonExistentKey_ShouldReturnNull() {
+      assertNull(map.remove(K_NON_EXIST), "Remove non-existent key should return null");
+      assertEquals(3, map.size(), "Size should not change");
+    }
+
+    @Test
+    @DisplayName("remove() from empty map")
+    void remove_FromEmptyMap_ShouldReturnNull() {
+      assertNull(mapEmpty.remove(K1));
+      assertTrue(mapEmpty.isEmpty());
+    }
+
+    @Test
+    @DisplayName("remove() should throw NullPointerException for null key")
+    void remove_NullKey_ShouldThrowNPE() {
+      assertThrows(NullPointerException.class, () -> map.remove(null), "Null key should throw NPE");
+    }
+
+    @Test
+    @DisplayName("containsKey() should work correctly")
+    void containsKey_ShouldReturnCorrectly() {
+      assertTrue(map.containsKey(K1));
+      assertTrue(map.containsKey(K2));
+      assertTrue(map.containsKey(K3));
+      assertFalse(map.containsKey(K4));
+      assertFalse(map.containsKey(K_NON_EXIST));
+      assertFalse(mapEmpty.containsKey(K1));
+    }
+
+    @Test
+    @DisplayName("containsKey() should throw NullPointerException for null key")
+    void containsKey_NullKey_ShouldThrowNPE() {
+      assertThrows(
+          NullPointerException.class, () -> map.containsKey(null), "Null key should throw NPE");
+    }
+
+    @Test
+    @DisplayName("containsValue() should work correctly")
+    void containsValue_ShouldReturnCorrectly() {
+      assertTrue(map.containsValue(V1));
+      assertTrue(map.containsValue(V2));
+      assertTrue(map.containsValue(V3));
+      assertFalse(map.containsValue(V4));
+      assertFalse(map.containsValue(V_NON_EXIST));
+      assertFalse(mapEmpty.containsValue(V1));
+    }
+
+    @Test
+    @DisplayName("containsValue() should throw NullPointerException for null value")
+    void containsValue_NullValue_ShouldThrowNPE() {
+      assertThrows(
+          NullPointerException.class, () -> map.containsValue(null), "Null value should throw NPE");
+    }
+
+    @Test
+    @DisplayName("size() should return correct size")
+    void size_ShouldReturnCorrectValue() {
+      assertEquals(3, map.size());
+      assertEquals(0, mapEmpty.size());
+      assertEquals(1, mapSingleElement.size());
+      map.put(K4, V4);
+      assertEquals(4, map.size());
+      map.remove(K1);
+      assertEquals(3, map.size());
+    }
+
+    @Test
+    @DisplayName("isEmpty() should return correct state")
+    void isEmpty_ShouldReturnCorrectValue() {
+      assertFalse(map.isEmpty());
+      assertTrue(mapEmpty.isEmpty());
+      assertFalse(mapSingleElement.isEmpty());
+      map.clear();
+      assertTrue(map.isEmpty());
+    }
+
+    @Test
+    @DisplayName("clear() should remove all elements")
+    void clear_ShouldRemoveAllElements() {
+      SequencedSet<Integer> ks = map.keySet();
+      SequencedCollection<String> vs = map.values();
+      SequencedSet<Map.Entry<Integer, String>> es = map.entrySet();
+      SequencedMap<Integer, String> rm = map.reversed();
+
+      assertFalse(map.isEmpty());
+      map.clear();
+
+      assertTrue(map.isEmpty(), "Map should be empty after clear");
+      assertEquals(0, map.size(), "Size should be 0 after clear");
+      assertNull(map.firstEntry(), "First entry should be null after clear");
+      assertNull(map.lastEntry(), "Last entry should be null after clear");
+      assertFalse(map.containsKey(K1), "Map should not contain keys after clear");
+      assertFalse(map.containsValue(V1), "Map should not contain values after clear");
+
+      // Check views obtained BEFORE clear are now empty
+      assertTrue(ks.isEmpty(), "Cached keySet should be empty after clear");
+      assertTrue(vs.isEmpty(), "Cached valuesView should be empty after clear");
+      assertTrue(es.isEmpty(), "Cached entrySet should be empty after clear");
+      assertTrue(rm.isEmpty(), "Cached reversedMap should be empty after clear");
+
+      // Check views obtained AFTER clear are also empty
+      assertTrue(map.isEmpty());
+      assertTrue(map.isEmpty());
+      assertTrue(map.isEmpty());
+      assertTrue(map.reversed().isEmpty());
+    }
+
+    @Test
+    @DisplayName("putAll() should add all elements using putLast semantics")
+    void putAll_ShouldAddAllElements() {
+      // Use LinkedHashMap for predictable iteration order for source
+      Map<Integer, String> sourceMap = new LinkedHashMap<>();
+      sourceMap.put(K4, V4);
+      sourceMap.put(K1, V_REPLACE);
+
+      map.putAll(sourceMap);
+
+      assertEquals(4, map.size(), "Size should be 4 after putAll");
+      assertEquals(V_REPLACE, map.get(K1), "Value for K1 should be updated");
+      assertEquals(V2, map.get(K2));
+      assertEquals(V3, map.get(K3));
+      assertEquals(V4, map.get(K4), "New element K4 should be added");
+      // putAll calls putLast, K1 is updated in place, K4 added last.
+      assertIterationOrder(map, List.of(K1, K2, K3, K4), List.of(V_REPLACE, V2, V3, V4));
+    }
+
+    @Test
+    @DisplayName("putAll() into empty map")
+    void putAll_IntoEmptyMap() {
+      // Use LinkedHashMap for predictable iteration order
+      Map<Integer, String> sourceMap = new LinkedHashMap<>();
+      sourceMap.put(K1, V1);
+      sourceMap.put(K2, V2);
+
+      mapEmpty.putAll(sourceMap);
+      assertEquals(2, mapEmpty.size());
+      assertEquals(V1, mapEmpty.get(K1));
+      assertEquals(V2, mapEmpty.get(K2));
+      // Order should reflect insertion order via putLast
+      assertIterationOrder(mapEmpty, List.of(K1, K2), List.of(V1, V2));
+    }
+
+    @Test
+    @DisplayName("putAll() with empty map")
+    void putAll_WithEmptyMap() {
+      map.putAll(Collections.emptyMap());
+      assertEquals(3, map.size()); // Size should not change
+      assertIterationOrder(
+          map, List.of(K1, K2, K3), List.of(V1, V2, V3)); // Order should not change
+    }
+
+    @Test
+    @DisplayName("putAll() should throw NullPointerException for null map")
+    void putAll_NullMap_ShouldThrowNPE() {
+      assertThrows(NullPointerException.class, () -> map.putAll(null));
+    }
+
+    @Test
+    @DisplayName("remove(key, value) should remove only if key and value match")
+    void remove_KeyValue_Matching() {
+      assertTrue(map.remove(K2, V2), "Should return true when key and value match");
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K2));
+    }
+
+    @Test
+    @DisplayName("remove(key, value) should not remove if value doesn't match")
+    void remove_KeyValue_ValueMismatch() {
+      assertFalse(map.remove(K2, "Wrong Value"), "Should return false when value mismatches");
+      assertEquals(3, map.size());
+      assertTrue(map.containsKey(K2));
+      assertEquals(V2, map.get(K2));
+    }
+
+    @Test
+    @DisplayName("remove(key, value) should not remove if key doesn't exist")
+    void remove_KeyValue_KeyNonExistent() {
+      assertFalse(map.remove(K_NON_EXIST, V1), "Should return false when key does not exist");
+      assertEquals(3, map.size());
+    }
+
+    @Test
+    @DisplayName("remove(key, value) should handle non-matching null value")
+    void remove_KeyValue_MapHasValueTargetIsNull() {
+      // Try removing key K1 with null value when V1 is stored
+      assertFalse(map.remove(K1, null));
+      assertEquals(3, map.size());
+      assertTrue(map.containsKey(K1));
+    }
+
+    @Test
+    @DisplayName("remove(key, value) should throw NullPointerException for null key")
+    void remove_KeyValue_NullArgs() {
+      assertThrows(NullPointerException.class, () -> map.remove(null, V1));
+    }
+  }
+
+  // =====================================================
+  // SequencedMap Operations Tests
+  // =====================================================
+  @Nested
+  @DisplayName("SequencedMap Operations")
+  class SequencedOperations {
+
+    @Test
+    @DisplayName("putFirst() should add to beginning if key is new")
+    void putFirst_NewKey_ShouldAddToBeginning() {
+      assertNull(map.putFirst(K4, V4));
+      assertEquals(4, map.size());
+      assertEquals(V4, map.get(K4));
+      assertEquals(K4, map.firstEntry().getKey());
+      assertEquals(V4, map.firstEntry().getValue());
+      assertEquals(K3, map.lastEntry().getKey());
+      assertIterationOrder(map, List.of(K4, K1, K2, K3), List.of(V4, V1, V2, V3));
+    }
+
+    @Test
+    @DisplayName("putFirst() should update value and return old if key exists, maintaining order")
+    void putFirst_ExistingKey_ShouldUpdateAndReturnOld() {
+      assertEquals(V2, map.putFirst(K2, V_REPLACE));
+      assertEquals(3, map.size());
+      assertEquals(V_REPLACE, map.get(K2));
+      // Order MUST NOT change
+      assertIterationOrder(map, List.of(K1, K2, K3), List.of(V1, V_REPLACE, V3));
+      assertEquals(K1, map.firstEntry().getKey());
+      assertEquals(K3, map.lastEntry().getKey());
+    }
+
+    @Test
+    @DisplayName("putFirst() into empty map")
+    void putFirst_EmptyMap() {
+      assertNull(mapEmpty.putFirst(K1, V1));
+      assertEquals(1, mapEmpty.size());
+      assertEquals(K1, mapEmpty.firstEntry().getKey());
+      assertEquals(K1, mapEmpty.lastEntry().getKey());
+      assertEquals(V1, mapEmpty.get(K1));
+    }
+
+    @Test
+    @DisplayName("putLast() should add to end if key is new")
+    void putLast_NewKey_ShouldAddToEnd() {
+      assertNull(map.putLast(K4, V4));
+      assertEquals(4, map.size());
+      assertEquals(V4, map.get(K4));
+      assertEquals(K1, map.firstEntry().getKey());
+      assertEquals(K4, map.lastEntry().getKey());
+      assertEquals(V4, map.lastEntry().getValue());
+      assertIterationOrder(map, List.of(K1, K2, K3, K4), List.of(V1, V2, V3, V4));
+    }
+
+    @Test
+    @DisplayName("putLast() should update value and return old if key exists, maintaining order")
+    void putLast_ExistingKey_ShouldUpdateAndReturnOld() {
+      assertEquals(V2, map.putLast(K2, V_REPLACE));
+      assertEquals(3, map.size());
+      assertEquals(V_REPLACE, map.get(K2));
+      // Order MUST NOT change
+      assertIterationOrder(map, List.of(K1, K2, K3), List.of(V1, V_REPLACE, V3));
+      assertEquals(K1, map.firstEntry().getKey());
+      assertEquals(K3, map.lastEntry().getKey());
+    }
+
+    @Test
+    @DisplayName("putLast() into empty map")
+    void putLast_EmptyMap() {
+      assertNull(mapEmpty.putLast(K1, V1));
+      assertEquals(1, mapEmpty.size());
+      assertEquals(K1, mapEmpty.firstEntry().getKey());
+      assertEquals(K1, mapEmpty.lastEntry().getKey());
+      assertEquals(V1, mapEmpty.get(K1));
+    }
+
+    @Test
+    @DisplayName("firstEntry() should return first element or null")
+    void firstEntry_ShouldReturnCorrectEntry() {
+      Map.Entry<Integer, String> first = map.firstEntry();
+      assertNotNull(first);
+      assertEquals(K1, first.getKey());
+      assertEquals(V1, first.getValue());
+
+      assertNull(mapEmpty.firstEntry());
+    }
+
+    @Test
+    @DisplayName("lastEntry() should return last element or null")
+    void lastEntry_ShouldReturnCorrectEntry() {
+      Map.Entry<Integer, String> last = map.lastEntry();
+      assertNotNull(last);
+      assertEquals(K3, last.getKey());
+      assertEquals(V3, last.getValue());
+
+      assertNull(mapEmpty.lastEntry());
+    }
+
+    @Test
+    @DisplayName("pollFirstEntry() should remove and return first element or null")
+    void pollFirstEntry_ShouldRemoveAndReturnFirst() {
+      Map.Entry<Integer, String> expectedFirst = map.firstEntry();
+      Map.Entry<Integer, String> polled = map.pollFirstEntry();
+      assertNotNull(polled);
+      assertEquals(expectedFirst, polled, "Polled entry should match first entry");
+      assertEquals(K1, polled.getKey());
+      assertEquals(V1, polled.getValue());
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K1));
+      assertEquals(K2, map.firstEntry().getKey());
+      assertIterationOrder(map, List.of(K2, K3), List.of(V2, V3));
+
+      // Poll next
+      Map.Entry<Integer, String> polled2 = map.pollFirstEntry();
+      assertEquals(K2, polled2.getKey());
+      assertEquals(1, map.size());
+
+      // Poll last remaining
+      Map.Entry<Integer, String> lastPolled = map.pollFirstEntry();
+      assertEquals(K3, lastPolled.getKey());
+      assertTrue(map.isEmpty());
+      assertNull(map.pollFirstEntry());
+    }
+
+    @Test
+    @DisplayName("pollFirstEntry() on empty map")
+    void pollFirstEntry_EmptyMap() {
+      assertNull(mapEmpty.pollFirstEntry());
+    }
+
+    @Test
+    @DisplayName("pollLastEntry() should remove and return last element or null")
+    void pollLastEntry_ShouldRemoveAndReturnLast() {
+      Map.Entry<Integer, String> expectedLast = map.lastEntry();
+      Map.Entry<Integer, String> polled = map.pollLastEntry();
+      assertNotNull(polled);
+      assertEquals(expectedLast, polled, "Polled entry should match last entry");
+      assertEquals(K3, polled.getKey());
+      assertEquals(V3, polled.getValue());
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K3));
+      assertEquals(K2, map.lastEntry().getKey());
+      assertIterationOrder(map, List.of(K1, K2), List.of(V1, V2));
+
+      // Poll next
+      Map.Entry<Integer, String> polled2 = map.pollLastEntry();
+      assertEquals(K2, polled2.getKey());
+      assertEquals(1, map.size());
+
+      // Poll last remaining
+      Map.Entry<Integer, String> lastPolled = map.pollLastEntry();
+      assertEquals(K1, lastPolled.getKey());
+      assertTrue(map.isEmpty());
+      assertNull(map.pollLastEntry());
+    }
+
+    @Test
+    @DisplayName("pollLastEntry() on empty map")
+    void pollLastEntry_EmptyMap() {
+      assertNull(mapEmpty.pollLastEntry());
+    }
+  }
+
+  // =====================================================
+  // KeySetView Tests
+  // =====================================================
+  @Nested
+  @DisplayName("KeySet View Tests")
+  class KeySetViewTests {
+    private SequencedSet<Integer> keySet;
+
+    @BeforeEach
+    void setUpView() {
+      keySet = map.keySet();
+    }
+
+    @Test
+    @DisplayName("Basic KeySet Operations")
+    void keySet_BasicOperations() {
+      testViewBasics(keySet, K2, K_NON_EXIST, 3);
+    }
+
+    @Test
+    @DisplayName("KeySet remove(Object o)")
+    void keySet_Remove() {
+      testViewRemove(keySet, K2, K2, 3);
+    }
+
+    @Test
+    @DisplayName("KeySet iterator remove()")
+    void keySet_IteratorRemove() {
+      testIteratorRemove(keySet, K2, K2, 3);
+    }
+
+    @Test
+    @DisplayName("KeySet Iteration Order (Forward)")
+    void keySet_IterationOrderForward() {
+      assertIterationOrderSpecific(keySet, List.of(K1, K2, K3));
+    }
+
+    @Test
+    @DisplayName("KeySet getFirst() / getLast()")
+    void keySet_GetFirstLast() {
+      assertEquals(K1, keySet.getFirst());
+      assertEquals(K3, keySet.getLast());
+      assertThrows(NoSuchElementException.class, mapEmpty.keySet()::getFirst);
+      assertThrows(NoSuchElementException.class, mapEmpty.keySet()::getLast);
+    }
+
+    @Test
+    @DisplayName("Map modification should reflect in KeySet")
+    void mapModification_ReflectsInKeySet() {
+      assertTrue(keySet.contains(K1));
+      map.remove(K1);
+      assertFalse(keySet.contains(K1), "KeySet should not contain removed key");
+      assertEquals(2, keySet.size(), "KeySet size should decrease");
+
+      map.put(K4, V4);
+      assertTrue(keySet.contains(K4), "KeySet should contain newly added key");
+      assertEquals(3, keySet.size(), "KeySet size should increase");
+    }
+
+    @Test
+    @DisplayName("KeySet modification should reflect in Map")
+    void keySetModification_ReflectsInMap() {
+      assertTrue(map.containsKey(K2));
+      keySet.remove(K2);
+      assertFalse(map.containsKey(K2), "Map should not contain key removed via keySet");
+      assertEquals(2, map.size(), "Map size should decrease");
+
+      keySet.clear();
+      assertTrue(map.isEmpty(), "Map should be empty after keySet clear");
+    }
+
+    @Nested
+    @DisplayName("Reversed KeySet View")
+    class ReversedKeySetTests {
+      private SequencedSet<Integer> reversedKeySet;
+
+      @BeforeEach
+      void setUpReversedView() {
+        reversedKeySet = keySet.reversed();
+        assertNotNull(reversedKeySet, "Reversed key set should not be null");
+      }
+
+      @Test
+      @DisplayName("Basic Reversed KeySet Operations")
+      void reversedKeySet_BasicOperations() {
+        testViewBasics(reversedKeySet, K2, K_NON_EXIST, 3);
+      }
+
+      @Test
+      @DisplayName("Reversed KeySet remove(Object o)")
+      void reversedKeySet_Remove() {
+        testViewRemove(reversedKeySet, K2, K2, 3);
+      }
+
+      @Test
+      @DisplayName("Reversed KeySet iterator remove()")
+      void reversedKeySet_IteratorRemove() {
+        // Test removing K2 via reversed iterator
+        testIteratorRemove(reversedKeySet, K2, K2, 3);
+        // Check remaining order
+        assertIterationOrderSpecific(reversedKeySet, List.of(K3, K1));
+      }
+
+      @Test
+      @DisplayName("Reversed KeySet Iteration Order")
+      void reversedKeySet_IterationOrder() {
+        assertIterationOrderSpecific(reversedKeySet, List.of(K3, K2, K1));
+      }
+
+      @Test
+      @DisplayName("Reversed KeySet getFirst() / getLast()")
+      void reversedKeySet_GetFirstLast() {
+        assertEquals(K3, reversedKeySet.getFirst());
+        assertEquals(K1, reversedKeySet.getLast());
+        assertThrows(NoSuchElementException.class, mapEmpty.keySet().reversed()::getFirst);
+        assertThrows(NoSuchElementException.class, mapEmpty.keySet().reversed()::getLast);
+      }
+
+      @Test
+      @DisplayName("reversed().reversed() should return original view instance")
+      void reversedReversed_ShouldBeOriginal() {
+        // Check if the same instance is returned (if cached)
+        assertSame(
+            keySet,
+            reversedKeySet.reversed(),
+            "reversed().reversed() should be the same instance if cached");
+        // Also check equality
+        assertEquals(keySet, reversedKeySet.reversed());
+      }
+    }
+  }
+
+  // =====================================================
+  // ValuesView Tests
+  // =====================================================
+  @Nested
+  @DisplayName("Values Collection View Tests")
+  class ValuesViewTests {
+    private SequencedCollection<String> valuesView;
+
+    @BeforeEach
+    void setUpView() {
+      valuesView = map.values();
+    }
+
+    @Test
+    @DisplayName("Basic Values Operations")
+    void values_BasicOperations() {
+      // Pass V_NON_EXIST as non-existing element
+      testViewBasics(valuesView, V2, V_NON_EXIST, 3);
+    }
+
+    @Test
+    @DisplayName("Values iterator remove()")
+    void values_IteratorRemove() {
+      // Remove V2 (associated with K2)
+      testIteratorRemove(valuesView, K2, V2, 3);
+    }
+
+    @Test
+    @DisplayName("Values Iteration Order (Forward)")
+    void values_IterationOrderForward() {
+      assertIterationOrderSpecific(valuesView, List.of(V1, V2, V3));
+    }
+
+    @Test
+    @DisplayName("Values getFirst() / getLast()")
+    void values_GetFirstLast() {
+      assertEquals(V1, valuesView.getFirst());
+      assertEquals(V3, valuesView.getLast());
+      assertThrows(NoSuchElementException.class, mapEmpty.values()::getFirst);
+      assertThrows(NoSuchElementException.class, mapEmpty.values()::getLast);
+    }
+
+    @Test
+    @DisplayName("Map modification should reflect in Values")
+    void mapModification_ReflectsInValues() {
+      assertTrue(valuesView.contains(V1));
+      map.remove(K1);
+      assertFalse(valuesView.contains(V1), "Values view should not contain value of removed key");
+      assertEquals(2, valuesView.size());
+
+      map.put(K4, V4);
+      assertTrue(valuesView.contains(V4), "Values view should contain newly added value");
+      assertEquals(3, valuesView.size());
+
+      map.put(K2, V_REPLACE);
+      assertTrue(valuesView.contains(V_REPLACE));
+      assertFalse(valuesView.contains(V2));
+      assertEquals(3, valuesView.size());
+    }
+
+    @Test
+    @DisplayName("Values modification (via iterator remove) should reflect in Map")
+    void valuesModification_ReflectsInMap() {
+      assertTrue(map.containsValue(V2));
+      testIteratorRemove(valuesView, K2, V2, 3);
+      assertFalse(map.containsValue(V2));
+      assertFalse(map.containsKey(K2));
+
+      valuesView.clear();
+      assertTrue(map.isEmpty());
+    }
+
+    // Tests for remove(Object o) in ValuesView - typically unsupported or less defined
+    @Test
+    @DisplayName("Values remove(Object o) - Check if supported/correct")
+    void values_RemoveObject() {
+      // AbstractCollection remove iterates and uses iterator.remove()
+      // It should remove the *first* occurrence
+      map.put(K4, V1);
+      assertIterationOrderSpecific(valuesView, List.of(V1, V2, V3, V1));
+      assertTrue(valuesView.remove(V1), "remove(V1) should return true");
+      assertEquals(3, valuesView.size());
+      assertEquals(3, map.size());
+      assertFalse(map.containsKey(K1), "First entry with V1 (K1) should be removed");
+      assertTrue(map.containsKey(K4), "Second entry with V1 (K4) should remain");
+      assertIterationOrderSpecific(valuesView, List.of(V2, V3, V1));
+
+      assertFalse(
+          valuesView.remove(V_NON_EXIST), "Removing non-existing value should return false");
+    }
+
+    @Nested
+    @DisplayName("Reversed Values Collection View")
+    class ReversedValuesTests {
+      private SequencedCollection<String> reversedValuesView;
+
+      @BeforeEach
+      void setUpReversedView() {
+        reversedValuesView = valuesView.reversed();
+        assertNotNull(reversedValuesView, "Reversed values view should not be null");
+      }
+
+      @Test
+      @DisplayName("Basic Reversed Values Operations")
+      void reversedValues_BasicOperations() {
+        testViewBasics(reversedValuesView, V2, V_NON_EXIST, 3);
+      }
+
+      @Test
+      @DisplayName("Reversed Values iterator remove()")
+      void reversedValues_IteratorRemove() {
+        // Remove V2 (associated with K2) via reversed iterator
+        testIteratorRemove(reversedValuesView, K2, V2, 3);
+        // Check remaining order
+        assertIterationOrderSpecific(reversedValuesView, List.of(V3, V1));
+      }
+
+      @Test
+      @DisplayName("Reversed Values Iteration Order")
+      void reversedValues_IterationOrder() {
+        assertIterationOrderSpecific(reversedValuesView, List.of(V3, V2, V1));
+      }
+
+      @Test
+      @DisplayName("Reversed Values getFirst() / getLast()")
+      void reversedValues_GetFirstLast() {
+        assertEquals(V3, reversedValuesView.getFirst());
+        assertEquals(V1, reversedValuesView.getLast());
+        assertThrows(NoSuchElementException.class, mapEmpty.values().reversed()::getFirst);
+        assertThrows(NoSuchElementException.class, mapEmpty.values().reversed()::getLast);
+      }
+
+      @Test
+      @DisplayName("reversed().reversed() should return original view instance")
+      void reversedReversed_ShouldBeOriginal() {
+        assertSame(
+            valuesView,
+            reversedValuesView.reversed(),
+            "reversed().reversed() should be the same instance if cached");
+        // Also check equality (AbstractCollection equals is based on iterator content/order)
+        assertEquals(valuesView.stream().toList(), reversedValuesView.reversed().stream().toList());
+      }
+    }
+  }
+
+  // =====================================================
+  // EntrySetView Tests
+  // =====================================================
+  @Nested
+  @DisplayName("EntrySet View Tests")
+  class EntrySetViewTests {
+    private SequencedSet<Map.Entry<Integer, String>> entrySet;
+    private Map.Entry<Integer, String> entry1;
+    private Map.Entry<Integer, String> entry2;
+    private Map.Entry<Integer, String> entry3;
+    private Map.Entry<Integer, String> nonExistingEntryKey;
+    private Map.Entry<Integer, String> nonExistingEntryValue;
+    private Map.Entry<Integer, String> nonExistingEntryBoth;
+
+    @BeforeEach
+    void setUpView() {
+      entrySet = map.entrySet();
+      // Use immutable entries for comparison
+      entry1 = new AbstractMap.SimpleImmutableEntry<>(K1, V1);
+      entry2 = new AbstractMap.SimpleImmutableEntry<>(K2, V2);
+      entry3 = new AbstractMap.SimpleImmutableEntry<>(K3, V3);
+      nonExistingEntryKey = new AbstractMap.SimpleImmutableEntry<>(K_NON_EXIST, V1);
+      nonExistingEntryValue = new AbstractMap.SimpleImmutableEntry<>(K1, V_NON_EXIST);
+      nonExistingEntryBoth = new AbstractMap.SimpleImmutableEntry<>(K_NON_EXIST, V_NON_EXIST);
+    }
+
+    @Test
+    @DisplayName("Basic EntrySet Operations")
+    void entrySet_BasicOperations() {
+      // Pass nonExistingEntryBoth as non-existing
+      testViewBasics(entrySet, entry2, nonExistingEntryBoth, 3);
+      // Specific contains checks for EntrySet
+      assertTrue(entrySet.contains(new AbstractMap.SimpleEntry<>(K1, V1)));
+      assertFalse(entrySet.contains(nonExistingEntryKey));
+      assertFalse(entrySet.contains(nonExistingEntryValue));
+      assertFalse(entrySet.contains(new Object()));
+    }
+
+    @Test
+    @DisplayName("EntrySet remove(Object o)")
+    void entrySet_Remove() {
+      testViewRemove(entrySet, entry2, K2, 3);
+      assertFalse(entrySet.remove(nonExistingEntryKey), "Removing non-existing key entry");
+      assertFalse(entrySet.remove(nonExistingEntryValue), "Removing non-existing value entry");
+      assertFalse(entrySet.remove(nonExistingEntryBoth), "Removing non-existing entry");
+      assertFalse(entrySet.remove(new Object()), "Removing wrong type");
+    }
+
+    @Test
+    @DisplayName("EntrySet iterator remove()")
+    void entrySet_IteratorRemove() {
+      // Remove entry2 (K2, V2)
+      testIteratorRemove(entrySet, K2, entry2, 3);
+      // Check remaining order
+      assertIterationOrderSpecific(entrySet, List.of(entry1, entry3));
+    }
+
+    @Test
+    @DisplayName("EntrySet Iteration Order (Forward)")
+    void entrySet_IterationOrderForward() {
+      assertIterationOrderSpecific(entrySet, List.of(entry1, entry2, entry3));
+    }
+
+    @Test
+    @DisplayName("EntrySet getFirst() / getLast()")
+    void entrySet_GetFirstLast() {
+      assertEquals(entry1, entrySet.getFirst());
+      assertEquals(entry3, entrySet.getLast());
+      assertThrows(NoSuchElementException.class, mapEmpty.entrySet()::getFirst);
+      assertThrows(NoSuchElementException.class, mapEmpty.entrySet()::getLast);
+    }
+
+    @Test
+    @DisplayName("Map modification should reflect in EntrySet")
+    void mapModification_ReflectsInEntrySet() {
+      assertTrue(entrySet.contains(entry1));
+      map.remove(K1);
+      assertFalse(entrySet.contains(entry1), "EntrySet should not contain entry of removed key");
+      assertEquals(2, entrySet.size());
+
+      map.put(K4, V4);
+      Map.Entry<Integer, String> entry4 = new AbstractMap.SimpleImmutableEntry<>(K4, V4);
+      assertTrue(entrySet.contains(entry4), "EntrySet should contain newly added entry");
+      assertEquals(3, entrySet.size());
+
+      map.put(K2, V_REPLACE);
+      Map.Entry<Integer, String> entry2Updated =
+          new AbstractMap.SimpleImmutableEntry<>(K2, V_REPLACE);
+      assertTrue(entrySet.contains(entry2Updated));
+      assertFalse(entrySet.contains(entry2));
+      assertEquals(3, entrySet.size());
+    }
+
+    @Test
+    @DisplayName("EntrySet modification should reflect in Map")
+    void entrySetModification_ReflectsInMap() {
+      assertTrue(map.containsKey(K2));
+      entrySet.remove(entry2);
+      assertFalse(map.containsKey(K2), "Map should not contain key removed via entrySet");
+      assertEquals(2, map.size());
+
+      entrySet.clear();
+      assertTrue(map.isEmpty(), "Map should be empty after entrySet clear");
+    }
+
+    // setValue() is not supported by the immutable entries returned by the current iterator
+    @Test
+    @DisplayName("EntrySet iterator setValue() should throw UnsupportedOperationException")
+    void entrySet_IteratorSetValue() {
+      Iterator<Map.Entry<Integer, String>> it = entrySet.iterator();
+      assertTrue(it.hasNext());
+      Map.Entry<Integer, String> first = it.next();
+      assertThrows(UnsupportedOperationException.class, () -> first.setValue(V_REPLACE));
+      assertEquals(V1, map.get(K1));
+    }
+
+    @Nested
+    @DisplayName("Reversed EntrySet View")
+    class ReversedEntrySetTests {
+      private SequencedSet<Map.Entry<Integer, String>> reversedEntrySet;
+
+      @BeforeEach
+      void setUpReversedView() {
+        reversedEntrySet = entrySet.reversed();
+        assertNotNull(reversedEntrySet, "Reversed entry set should not be null");
+      }
+
+      @Test
+      @DisplayName("Basic Reversed EntrySet Operations")
+      void reversedEntrySet_BasicOperations() {
+        testViewBasics(reversedEntrySet, entry2, nonExistingEntryBoth, 3);
+      }
+
+      @Test
+      @DisplayName("Reversed EntrySet remove(Object o)")
+      void reversedEntrySet_Remove() {
+        testViewRemove(reversedEntrySet, entry2, K2, 3);
+      }
+
+      @Test
+      @DisplayName("Reversed EntrySet iterator remove()")
+      void reversedEntrySet_IteratorRemove() {
+        // Remove entry2 (K2, V2) via reversed iterator
+        testIteratorRemove(reversedEntrySet, K2, entry2, 3);
+        // Check remaining order
+        assertIterationOrderSpecific(reversedEntrySet, List.of(entry3, entry1));
+      }
+
+      @Test
+      @DisplayName("Reversed EntrySet Iteration Order")
+      void reversedEntrySet_IterationOrder() {
+        assertIterationOrderSpecific(reversedEntrySet, List.of(entry3, entry2, entry1));
+      }
+
+      @Test
+      @DisplayName("Reversed EntrySet getFirst() / getLast()")
+      void reversedEntrySet_GetFirstLast() {
+        assertEquals(entry3, reversedEntrySet.getFirst());
+        assertEquals(entry1, reversedEntrySet.getLast());
+        assertThrows(NoSuchElementException.class, mapEmpty.entrySet().reversed()::getFirst);
+        assertThrows(NoSuchElementException.class, mapEmpty.entrySet().reversed()::getLast);
+      }
+
+      @Test
+      @DisplayName("reversed().reversed() should return original view instance")
+      void reversedReversed_ShouldBeOriginal() {
+        assertSame(
+            entrySet,
+            reversedEntrySet.reversed(),
+            "reversed().reversed() should be the same instance if cached");
+        assertEquals(entrySet, reversedEntrySet.reversed());
+      }
+    }
+  }
+
+  // =====================================================
+  // Reversed Map Tests
+  // =====================================================
+  @Nested
+  @DisplayName("Reversed Map View Tests")
+  class ReversedMapTests {
+    private SequencedMap<Integer, String> reversedMap;
+
+    @BeforeEach
+    void setUpReversedMap() {
+      reversedMap = map.reversed();
+      assertNotNull(reversedMap, "Reversed map should not be null");
+    }
+
+    @Test
+    @DisplayName("Basic Reversed Map Operations")
+    void reversed_BasicOperations() {
+      assertEquals(3, reversedMap.size());
+      assertFalse(reversedMap.isEmpty());
+      assertTrue(reversedMap.containsKey(K2));
+      assertTrue(reversedMap.containsValue(V2));
+      assertEquals(V1, reversedMap.get(K1));
+      assertNull(reversedMap.get(K_NON_EXIST));
+    }
+
+    @Test
+    @DisplayName("reversed().reversed() should return original map instance")
+    void reversedReversed_ShouldBeOriginal() {
+      assertSame(
+          map,
+          reversedMap.reversed(),
+          "reversed().reversed() should be the same instance if cached");
+      assertEquals(map, reversedMap.reversed());
+    }
+
+    @Test
+    @DisplayName("firstEntry() / lastEntry() on Reversed Map")
+    void reversed_FirstLastEntry() {
+      assertEquals(map.lastEntry(), reversedMap.firstEntry());
+      assertEquals(map.firstEntry(), reversedMap.lastEntry());
+      assertNull(mapEmpty.reversed().firstEntry());
+      assertNull(mapEmpty.reversed().lastEntry());
+    }
+
+    @Test
+    @DisplayName("pollFirstEntry() / pollLastEntry() on Reversed Map")
+    void reversed_PollFirstLastEntry() {
+      Map.Entry<Integer, String> originalLast = map.lastEntry();
+
+      Map.Entry<Integer, String> polledFirstReversed = reversedMap.pollFirstEntry();
+      assertEquals(originalLast, polledFirstReversed);
+      assertEquals(2, reversedMap.size());
+      assertEquals(2, map.size());
+      assertFalse(reversedMap.containsKey(K3));
+      assertEquals(map.lastEntry(), reversedMap.firstEntry());
+
+      Map.Entry<Integer, String> polledLastReversed = reversedMap.pollLastEntry();
+      assertEquals(K1, polledLastReversed.getKey());
+      assertEquals(V1, polledLastReversed.getValue());
+      assertEquals(1, reversedMap.size());
+      assertEquals(1, map.size());
+      assertFalse(reversedMap.containsKey(K1));
+      assertEquals(map.firstEntry(), reversedMap.lastEntry());
+      assertEquals(map.lastEntry(), reversedMap.firstEntry());
+    }
+
+    @Test
+    @DisplayName("putFirst() on Reversed Map adds to original end")
+    void reversed_PutFirst() {
+      assertNull(reversedMap.putFirst(K4, V4));
+      assertEquals(4, map.size());
+      assertEquals(K4, map.lastEntry().getKey());
+      assertEquals(K1, map.firstEntry().getKey());
+      assertEquals(K1, reversedMap.lastEntry().getKey());
+      assertEquals(K4, reversedMap.firstEntry().getKey());
+      assertIterationOrder(map, List.of(K1, K2, K3, K4), List.of(V1, V2, V3, V4));
+    }
+
+    @Test
+    @DisplayName("putLast() on Reversed Map adds to original start")
+    void reversed_PutLast() {
+      assertNull(reversedMap.putLast(K4, V4));
+      assertEquals(4, map.size());
+      assertEquals(K4, map.firstEntry().getKey());
+      assertEquals(K3, map.lastEntry().getKey());
+      assertEquals(K3, reversedMap.firstEntry().getKey());
+      assertEquals(K4, reversedMap.lastEntry().getKey());
+      assertIterationOrder(map, List.of(K4, K1, K2, K3), List.of(V4, V1, V2, V3));
+    }
+
+    @Test
+    @DisplayName("put() on Reversed Map updates or adds to original start")
+    void reversed_Put() {
+      // Test add new (putLast on reversed -> putFirst on original)
+      assertNull(reversedMap.put(K4, V4));
+      assertEquals(4, map.size());
+      assertEquals(K4, map.firstEntry().getKey());
+      assertEquals(K4, reversedMap.lastEntry().getKey());
+      assertIterationOrder(map, List.of(K4, K1, K2, K3), List.of(V4, V1, V2, V3));
+
+      // Test update existing
+      assertEquals(V2, reversedMap.put(K2, V_REPLACE));
+      assertEquals(4, map.size());
+      assertEquals(V_REPLACE, map.get(K2));
+      // Order should not change for updated element
+      assertIterationOrder(map, List.of(K4, K1, K2, K3), List.of(V4, V1, V_REPLACE, V3));
+    }
+
+    @Test
+    @DisplayName("putAll() on Reversed Map")
+    void reversed_PutAll() {
+      Map<Integer, String> source = new LinkedHashMap<>();
+      source.put(K4, V4);
+      source.put(K1, V_REPLACE);
+
+      reversedMap.putAll(source);
+
+      assertEquals(4, map.size());
+      assertEquals(V_REPLACE, map.get(K1));
+      assertEquals(V4, map.get(K4));
+      assertIterationOrder(map, List.of(K4, K1, K2, K3), List.of(V4, V_REPLACE, V2, V3));
+    }
+
+    @Test
+    @DisplayName("Views obtained from Reversed Map iterate in reverse")
+    void reversed_Views() {
+      SequencedSet<Integer> rk = (SequencedSet<Integer>) reversedMap.keySet();
+      SequencedCollection<String> rv = (SequencedCollection<String>) reversedMap.values();
+      SequencedSet<Map.Entry<Integer, String>> re =
+          (SequencedSet<Map.Entry<Integer, String>>) reversedMap.entrySet();
+
+      // Check iteration order
+      assertIterationOrderSpecific(rk, List.of(K3, K2, K1));
+      assertIterationOrderSpecific(rv, List.of(V3, V2, V1));
+      // Create expected reversed entries
+      List<Map.Entry<Integer, String>> expectedEntries =
+          List.of(
+              new AbstractMap.SimpleImmutableEntry<>(K3, V3),
+              new AbstractMap.SimpleImmutableEntry<>(K2, V2),
+              new AbstractMap.SimpleImmutableEntry<>(K1, V1));
+      assertIterationOrderSpecific(re, expectedEntries);
+
+      // Check first/last
+      assertEquals(K3, rk.getFirst());
+      assertEquals(K1, rk.getLast());
+      assertEquals(V3, rv.getFirst());
+      assertEquals(V1, rv.getLast());
+      assertEquals(expectedEntries.get(0), re.getFirst());
+      assertEquals(expectedEntries.get(2), re.getLast());
+
+      // Check modification via reversed view's view
+      rk.remove(K2);
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K2));
+      assertIterationOrderSpecific(rk, List.of(K3, K1));
+    }
+
+    @Test
+    @DisplayName("clear() via Reversed Map")
+    void reversed_Clear() {
+      assertFalse(map.isEmpty());
+      reversedMap.clear();
+      assertTrue(map.isEmpty());
+      assertTrue(reversedMap.isEmpty());
+    }
+
+    @Test
+    @DisplayName("equals() and hashCode() on Reversed Map")
+    void reversed_EqualsHashCode() {
+      CustomLinkedHashMap<Integer, String> map2 = new CustomLinkedHashMap<>();
+      map2.put(K1, V1);
+      map2.put(K2, V2);
+      map2.put(K3, V3);
+
+      assertEquals(reversedMap, map, "ReversedMapView equals check needs adjustment for type");
+      assertEquals(map, map2);
+      assertEquals(
+          map.hashCode(),
+          reversedMap.hashCode(),
+          "Reversed map hashcode should equal original map hashcode");
+    }
+  }
+
+  // =====================================================
+  // Iterable Tests
+  // =====================================================
+  @Nested
+  @DisplayName("Iterable<V> Tests")
+  class IterableTests {
+    @Test
+    @DisplayName("Direct iterator() iterates values in order")
+    void iterator_IteratesValuesInOrder() {
+      List<String> iteratedValues = new ArrayList<>();
+      map.iterator().forEachRemaining(iteratedValues::add);
+      assertEquals(List.of(V1, V2, V3), iteratedValues);
+    }
+
+    @Test
+    @DisplayName("Direct iterator() remove() works")
+    void iterator_RemoveWorks() {
+      Iterator<String> it = map.iterator();
+      assertTrue(it.hasNext());
+      assertEquals(V1, it.next());
+      assertTrue(it.hasNext());
+      assertEquals(V2, it.next());
+      it.remove();
+
+      assertEquals(2, map.size());
+      assertFalse(map.containsKey(K2));
+      assertFalse(map.containsValue(V2));
+      assertIterationOrder(map, List.of(K1, K3), List.of(V1, V3));
+
+      // Test exceptions
+      assertThrows(IllegalStateException.class, it::remove);
+      it = map.iterator();
+      assertThrows(IllegalStateException.class, it::remove);
+    }
+
+    @Test
+    @DisplayName("Direct iterator() on empty map")
+    void iterator_EmptyMap() {
+      Iterator<String> it = mapEmpty.iterator();
+      assertFalse(it.hasNext());
+      assertThrows(NoSuchElementException.class, it::next);
+    }
+  }
+
+  // =====================================================
+  // Comparable Tests
+  // =====================================================
+  @Nested
+  @DisplayName("Comparable Tests")
+  class ComparableTests {
+    @Test
+    @DisplayName("compareTo() compares based on size")
+    void compareTo_ComparesBySize() {
+      CustomLinkedHashMap<Integer, String> smaller = new CustomLinkedHashMap<>();
+      smaller.put(1, "A");
+      CustomLinkedHashMap<Integer, String> larger = new CustomLinkedHashMap<>();
+      larger.put(1, "A");
+      larger.put(2, "B");
+      larger.put(3, "C");
+      larger.put(4, "D");
+
+      assertTrue(map.compareTo(mapEmpty) > 0, "map should be greater than empty");
+      assertTrue(mapEmpty.compareTo(map) < 0, "empty should be less than map");
+      assertTrue(map.compareTo(smaller) > 0, "map should be greater than smaller");
+      assertTrue(smaller.compareTo(map) < 0, "smaller should be less than map");
+      assertTrue(map.compareTo(larger) < 0, "map should be less than larger");
+      assertTrue(larger.compareTo(map) > 0, "larger should be greater than map");
+
+      CustomLinkedHashMap<Integer, String> sameSize = new CustomLinkedHashMap<>();
+      sameSize.put(10, "X");
+      sameSize.put(20, "Y");
+      sameSize.put(30, "Z");
+      assertEquals(0, map.compareTo(sameSize), "Maps of same size should compare equal");
+      assertEquals(0, sameSize.compareTo(map), "Maps of same size should compare equal");
+
+      assertEquals(0, map.compareTo(map), "Map should compare equal to itself");
+    }
+
+    @Test
+    @DisplayName("compareTo() throws NullPointerException for null argument")
+    void compareTo_NullArgument_ThrowsNPE() {
+      assertThrows(NullPointerException.class, () -> map.compareTo(null));
+    }
+  }
+
+  // =====================================================
+  // equals() and hashCode() Tests
+  // =====================================================
+  @Nested
+  @DisplayName("equals() and hashCode() Tests")
+  class EqualsHashCodeTests {
+
+    @Test
+    @DisplayName("equals() reflexive")
+    void equals_Reflexive() {
+      assertEquals(map, map, "Map should be equal to itself");
+    }
+
+    @Test
+    @DisplayName("equals() symmetric")
+    void equals_Symmetric() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      assertEquals(map, map2, "Maps with same elements and order should be equal");
+      assertEquals(map2, map, "Equality should be symmetric");
+    }
+
+    @Test
+    @DisplayName("equals() transitive")
+    void equals_Transitive() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      CustomLinkedHashMap<Integer, String> map3 = createCopy(map);
+      assertEquals(map, map2);
+      assertEquals(map2, map3);
+      assertEquals(map, map3, "Equality should be transitive");
+    }
+
+    @Test
+    @DisplayName("equals() consistent")
+    void equals_Consistent() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      assertEquals(map, map2);
+      // No modifications, should still be equal
+      assertEquals(map, map2);
+    }
+
+    @Test
+    @DisplayName("equals() null returns false")
+    void equals_Null() {
+      assertNotEquals(null, map, "equals(null) should return false");
+      assertNotEquals(null, map);
+    }
+
+    @Test
+    @DisplayName("equals() different type returns false")
+    void equals_DifferentType() {
+      assertNotEquals("Not a Map", map);
+      assertNotEquals(List.of(1, 2, 3), map);
+    }
+
+    @Test
+    @DisplayName("equals() different size returns false")
+    void equals_DifferentSize() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      map2.remove(K1);
+      assertNotEquals(map, map2);
+    }
+
+    @Test
+    @DisplayName("equals() different keys returns false")
+    void equals_DifferentKeys() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      map2.remove(K3);
+      map2.put(K_NON_EXIST, V3);
+      assertNotEquals(map, map2);
+    }
+
+    @Test
+    @DisplayName("equals() different values returns false")
+    void equals_DifferentValues() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      map2.put(K3, V_NON_EXIST);
+      assertNotEquals(map, map2);
+    }
+
+    @Test
+    @DisplayName("equals() different order returns true (Map contract)")
+    void equals_DifferentOrderReturnsTrue() {
+      // Standard Map.equals contract ignores order
+      CustomLinkedHashMap<Integer, String> mapOutOfOrder = new CustomLinkedHashMap<>();
+      mapOutOfOrder.put(K3, V3);
+      mapOutOfOrder.put(K1, V1);
+      mapOutOfOrder.put(K2, V2);
+
+      assertEquals(
+          map,
+          mapOutOfOrder,
+          "Maps with same elements but different insertion order should be equal by Map contract");
+      assertEquals(mapOutOfOrder, map);
+    }
+
+    @Test
+    @DisplayName("hashCode() consistent")
+    void hashCode_Consistent() {
+      int hc1 = map.hashCode();
+      int hc2 = map.hashCode();
+      assertEquals(hc1, hc2, "hashCode should be consistent across calls");
+    }
+
+    @Test
+    @DisplayName("hashCode() equals objects have equals hashCodes")
+    void hashCode_EqualsObjects() {
+      CustomLinkedHashMap<Integer, String> map2 = createCopy(map);
+      assertEquals(map, map2, "Maps should be equal");
+      assertEquals(map.hashCode(), map2.hashCode(), "Equal maps should have equal hashCodes");
+
+      // Test with different order (should still be equal hashcode by Map contract)
+      CustomLinkedHashMap<Integer, String> mapOutOfOrder = new CustomLinkedHashMap<>();
+      mapOutOfOrder.put(K3, V3);
+      mapOutOfOrder.put(K1, V1);
+      mapOutOfOrder.put(K2, V2);
+      assertEquals(map, mapOutOfOrder, "Maps should be equal regardless of order");
+      assertEquals(
+          map.hashCode(),
+          mapOutOfOrder.hashCode(),
+          "Equal maps (regardless of order) should have equal hashCodes");
+    }
+
+    @Test
+    @DisplayName("hashCode() for empty map")
+    void hashCode_EmptyMap() {
+      assertEquals(0, mapEmpty.hashCode());
+    }
+  }
+
+  // =====================================================
+  // Cache Tests (Optional)
+  // =====================================================
+  @Nested
+  @DisplayName("View Caching Tests")
+  class CacheTests {
+
+    @Test
+    @DisplayName("Views should return same instance if cached")
+    void views_ShouldReturnSameInstance() {
+      SequencedSet<Integer> ks1 = map.keySet();
+      SequencedSet<Integer> ks2 = map.keySet();
+      assertSame(ks1, ks2, "keySet() should return cached instance");
+
+      SequencedCollection<String> vs1 = map.values();
+      SequencedCollection<String> vs2 = map.values();
+      assertSame(vs1, vs2, "values() should return cached instance");
+
+      SequencedSet<Map.Entry<Integer, String>> es1 = map.entrySet();
+      SequencedSet<Map.Entry<Integer, String>> es2 = map.entrySet();
+      assertSame(es1, es2, "entrySet() should return cached instance");
+
+      SequencedMap<Integer, String> rm1 = map.reversed();
+      SequencedMap<Integer, String> rm2 = map.reversed();
+      assertSame(rm1, rm2, "reversed() should return cached instance");
+    }
+
+    @Test
+    @DisplayName("Cache should be invalidated after clear()")
+    void cache_ShouldBeInvalidatedAfterClear() {
+      SequencedSet<Integer> ks1 = map.keySet();
+      SequencedCollection<String> vs1 = map.values();
+      SequencedSet<Map.Entry<Integer, String>> es1 = map.entrySet();
+      SequencedMap<Integer, String> rm1 = map.reversed();
+
+      map.clear(); // Clear should reset caches
+
+      SequencedSet<Integer> ks2 = map.keySet();
+      SequencedCollection<String> vs2 = map.values();
+      SequencedSet<Map.Entry<Integer, String>> es2 = map.entrySet();
+      SequencedMap<Integer, String> rm2 = map.reversed();
+
+      assertNotSame(ks1, ks2, "keySet cache should be reset after clear");
+      assertNotSame(vs1, vs2, "values cache should be reset after clear");
+      assertNotSame(es1, es2, "entrySet cache should be reset after clear");
+      assertNotSame(rm1, rm2, "reversed map cache should be reset after clear");
+
+      assertTrue(ks2.isEmpty());
+      assertTrue(vs2.isEmpty());
+      assertTrue(es2.isEmpty());
+      assertTrue(rm2.isEmpty());
+    }
+  }
+}

--- a/src/test/java/com/tasktracker/task/manager/InMemoryHistoryManagerTest.java
+++ b/src/test/java/com/tasktracker/task/manager/InMemoryHistoryManagerTest.java
@@ -267,7 +267,7 @@ class InMemoryHistoryManagerTest {
     historyManager.put(t1);
     historyManager.put(t2);
     historyManager.put(t3);
-    System.out.println(historyManager.put(t2));
+    historyManager.put(t2);
     Collection<TaskView> history = historyManager.getHistory();
     assertEquals(3, history.size());
     System.out.println(historyManager.getHistory());

--- a/src/test/java/com/tasktracker/task/manager/InMemoryTaskManagerTest.java
+++ b/src/test/java/com/tasktracker/task/manager/InMemoryTaskManagerTest.java
@@ -121,7 +121,7 @@ public class InMemoryTaskManagerTest {
     assertEquals(TaskStatus.NEW, created.getStatus());
     assertEquals(epicTask.getId(), created.getEpicTaskId());
 
-    EpicTask updatedEpic = (EpicTask) manager.getTaskById(epicTask.getId()).get();
+    EpicTask updatedEpic = (EpicTask) manager.getTask(epicTask.getId()).get();
     assertTrue(updatedEpic.getSubtaskIds().contains(created.getId()));
   }
 
@@ -183,7 +183,7 @@ public class InMemoryTaskManagerTest {
             subTask1.getId(), VALID_TITLE, VALID_DESCRIPTION, TaskStatus.DONE, epicTask.getId());
     manager.updateTask(dto);
 
-    EpicTask updatedEpic = (EpicTask) manager.getTaskById(epicTask.getId()).get();
+    EpicTask updatedEpic = (EpicTask) manager.getTask(epicTask.getId()).get();
     assertEquals(TaskStatus.IN_PROGRESS, updatedEpic.getStatus());
 
     dto =
@@ -191,7 +191,7 @@ public class InMemoryTaskManagerTest {
             subTask2.getId(), VALID_TITLE, VALID_DESCRIPTION, TaskStatus.DONE, epicTask.getId());
     manager.updateTask(dto);
 
-    updatedEpic = (EpicTask) manager.getTaskById(epicTask.getId()).get();
+    updatedEpic = (EpicTask) manager.getTask(epicTask.getId()).get();
     assertEquals(TaskStatus.DONE, updatedEpic.getStatus());
   }
 
@@ -204,7 +204,7 @@ public class InMemoryTaskManagerTest {
 
     assertTrue(removed.isPresent());
     assertEquals(created.getId(), removed.get().getId());
-    assertFalse(manager.getTaskById(created.getId()).isPresent());
+    assertFalse(manager.getTask(created.getId()).isPresent());
   }
 
   @Test
@@ -220,12 +220,12 @@ public class InMemoryTaskManagerTest {
         new SubTaskUpdateDTO(
             sub1.getId(), VALID_TITLE, VALID_DESCRIPTION, TaskStatus.DONE, epic.getId()));
     manager.removeTaskById(sub1.getId());
-    EpicTask updatedEpic = (EpicTask) manager.getTaskById(epic.getId()).orElseThrow();
+    EpicTask updatedEpic = (EpicTask) manager.getTask(epic.getId()).orElseThrow();
 
-    assertFalse(manager.getTaskById(sub1.getId()).isPresent());
+    assertFalse(manager.getTask(sub1.getId()).isPresent());
     assertEquals(1, updatedEpic.getSubtaskIds().size());
     assertEquals(TaskStatus.NEW, updatedEpic.getStatus());
-    Optional<Task> removedSub1 = manager.getTaskById(sub1.getId());
+    Optional<Task> removedSub1 = manager.getTask(sub1.getId());
     assertFalse(removedSub1.isPresent());
   }
 
@@ -241,9 +241,9 @@ public class InMemoryTaskManagerTest {
     Optional<Task> removed = manager.removeTaskById(epic.getId());
 
     assertTrue(removed.isPresent());
-    assertFalse(manager.getTaskById(epic.getId()).isPresent());
-    assertFalse(manager.getTaskById(sub1.getId()).isPresent());
-    assertFalse(manager.getTaskById(sub2.getId()).isPresent());
+    assertFalse(manager.getTask(epic.getId()).isPresent());
+    assertFalse(manager.getTask(sub1.getId()).isPresent());
+    assertFalse(manager.getTask(sub2.getId()).isPresent());
   }
 
   @Test
@@ -276,7 +276,7 @@ public class InMemoryTaskManagerTest {
 
     assertTrue(removed);
     assertTrue(manager.getAllTasksByClass(SubTask.class).isEmpty());
-    EpicTask updatedEpic = (EpicTask) manager.getTaskById(epic.getId()).orElseThrow();
+    EpicTask updatedEpic = (EpicTask) manager.getTask(epic.getId()).orElseThrow();
     assertTrue(updatedEpic.getSubtaskIds().isEmpty());
     assertEquals(TaskStatus.IN_PROGRESS, updatedEpic.getStatus());
   }
@@ -326,10 +326,10 @@ public class InMemoryTaskManagerTest {
         new SubTaskUpdateDTO(
             sub2.getId(), VALID_TITLE, VALID_DESCRIPTION, TaskStatus.IN_PROGRESS, epic.getId()));
     manager.removeTaskById(sub2.getId());
-    EpicTask updatedEpic = (EpicTask) manager.getTaskById(epic.getId()).orElseThrow();
+    EpicTask updatedEpic = (EpicTask) manager.getTask(epic.getId()).orElseThrow();
 
     assertEquals(TaskStatus.DONE, updatedEpic.getStatus());
-    assertFalse(manager.getTaskById(sub2.getId()).isPresent());
+    assertFalse(manager.getTask(sub2.getId()).isPresent());
   }
 
   @Test
@@ -349,10 +349,10 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     assertTrue(removed.isPresent());
-    assertFalse(manager.getTaskById(regularTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(epicTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(subTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(anotherRegularTask.getId()).isPresent());
+    assertFalse(manager.getTask(regularTask.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask.getId()).isPresent());
+    assertTrue(manager.getTask(subTask.getId()).isPresent());
+    assertTrue(manager.getTask(anotherRegularTask.getId()).isPresent());
   }
 
   @Test
@@ -372,11 +372,11 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     assertTrue(removed.isPresent());
-    assertFalse(manager.getTaskById(subTask1.getId()).isPresent());
-    assertTrue(manager.getTaskById(subTask2.getId()).isPresent());
-    assertTrue(manager.getTaskById(regularTask.getId()).isPresent());
+    assertFalse(manager.getTask(subTask1.getId()).isPresent());
+    assertTrue(manager.getTask(subTask2.getId()).isPresent());
+    assertTrue(manager.getTask(regularTask.getId()).isPresent());
 
-    EpicTask updatedEpic = (EpicTask) manager.getTaskById(epicTask.getId()).orElseThrow();
+    EpicTask updatedEpic = (EpicTask) manager.getTask(epicTask.getId()).orElseThrow();
     assertFalse(updatedEpic.getSubtaskIds().contains(subTask1.getId()));
     assertTrue(updatedEpic.getSubtaskIds().contains(subTask2.getId()));
   }
@@ -399,11 +399,11 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     assertTrue(removed.isPresent());
-    assertFalse(manager.getTaskById(epicTask1.getId()).isPresent());
-    assertFalse(manager.getTaskById(subTask1.getId()).isPresent());
-    assertFalse(manager.getTaskById(subTask2.getId()).isPresent());
-    assertTrue(manager.getTaskById(epicTask2.getId()).isPresent());
-    assertTrue(manager.getTaskById(regularTask.getId()).isPresent());
+    assertFalse(manager.getTask(epicTask1.getId()).isPresent());
+    assertFalse(manager.getTask(subTask1.getId()).isPresent());
+    assertFalse(manager.getTask(subTask2.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask2.getId()).isPresent());
+    assertTrue(manager.getTask(regularTask.getId()).isPresent());
   }
 
   @Test
@@ -424,8 +424,8 @@ public class InMemoryTaskManagerTest {
     // Assert
     assertTrue(removedRegular);
     assertTrue(manager.getAllTasksByClass(RegularTask.class).isEmpty());
-    assertTrue(manager.getTaskById(epicTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(subTask.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask.getId()).isPresent());
+    assertTrue(manager.getTask(subTask.getId()).isPresent());
   }
 
   @Test
@@ -447,12 +447,12 @@ public class InMemoryTaskManagerTest {
     // Assert
     assertTrue(removedSubTasks);
     assertTrue(manager.getAllTasksByClass(SubTask.class).isEmpty());
-    assertTrue(manager.getTaskById(epicTask1.getId()).isPresent());
-    assertTrue(manager.getTaskById(epicTask2.getId()).isPresent());
-    assertTrue(manager.getTaskById(regularTask.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask1.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask2.getId()).isPresent());
+    assertTrue(manager.getTask(regularTask.getId()).isPresent());
 
-    EpicTask updatedEpic1 = (EpicTask) manager.getTaskById(epicTask1.getId()).orElseThrow();
-    EpicTask updatedEpic2 = (EpicTask) manager.getTaskById(epicTask2.getId()).orElseThrow();
+    EpicTask updatedEpic1 = (EpicTask) manager.getTask(epicTask1.getId()).orElseThrow();
+    EpicTask updatedEpic2 = (EpicTask) manager.getTask(epicTask2.getId()).orElseThrow();
     assertTrue(updatedEpic1.getSubtaskIds().isEmpty());
     assertTrue(updatedEpic2.getSubtaskIds().isEmpty());
     assertEquals(TaskStatus.NEW, updatedEpic1.getStatus());
@@ -474,9 +474,9 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     assertFalse(removed.isPresent());
-    assertTrue(manager.getTaskById(regularTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(epicTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(subTask.getId()).isPresent());
+    assertTrue(manager.getTask(regularTask.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask.getId()).isPresent());
+    assertTrue(manager.getTask(subTask.getId()).isPresent());
   }
 
   @Test
@@ -493,8 +493,8 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     assertFalse(removed);
-    assertTrue(manager.getTaskById(epicTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(subTask.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask.getId()).isPresent());
+    assertTrue(manager.getTask(subTask.getId()).isPresent());
   }
 
   @Test
@@ -514,8 +514,8 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     assertFalse(removed.isPresent());
-    assertTrue(manager.getTaskById(regularTask.getId()).isPresent());
-    assertTrue(manager.getTaskById(epicTask.getId()).isPresent());
+    assertTrue(manager.getTask(regularTask.getId()).isPresent());
+    assertTrue(manager.getTask(epicTask.getId()).isPresent());
   }
 
   @Test
@@ -537,9 +537,9 @@ public class InMemoryTaskManagerTest {
     // Assert
     assertTrue(removedEpics);
     assertTrue(manager.getAllTasksByClass(EpicTask.class).isEmpty());
-    assertFalse(manager.getTaskById(subTask1.getId()).isPresent());
-    assertFalse(manager.getTaskById(subTask2.getId()).isPresent());
-    assertTrue(manager.getTaskById(regularTask.getId()).isPresent());
+    assertFalse(manager.getTask(subTask1.getId()).isPresent());
+    assertFalse(manager.getTask(subTask2.getId()).isPresent());
+    assertTrue(manager.getTask(regularTask.getId()).isPresent());
   }
 
   @Test
@@ -571,14 +571,14 @@ public class InMemoryTaskManagerTest {
 
     // Assert
     // Regular2 should still exist
-    assertTrue(manager.getTaskById(regular2.getId()).isPresent());
+    assertTrue(manager.getTask(regular2.getId()).isPresent());
     // Epic1 and Epic2 should be removed
-    assertFalse(manager.getTaskById(epic1.getId()).isPresent());
-    assertFalse(manager.getTaskById(epic2.getId()).isPresent());
+    assertFalse(manager.getTask(epic1.getId()).isPresent());
+    assertFalse(manager.getTask(epic2.getId()).isPresent());
     // Sub2 should be removed because epic2 was removed
-    assertFalse(manager.getTaskById(sub2.getId()).isPresent());
+    assertFalse(manager.getTask(sub2.getId()).isPresent());
     // Sub1 was already removed
-    assertFalse(manager.getTaskById(sub1.getId()).isPresent());
+    assertFalse(manager.getTask(sub1.getId()).isPresent());
   }
 
   @Test
@@ -608,7 +608,7 @@ public class InMemoryTaskManagerTest {
         manager.addTask(new RegularTaskCreationDTO(VALID_TITLE, VALID_DESCRIPTION));
 
     // Act
-    manager.getTaskById(regularTask.getId()); // доступ к задаче
+    manager.getTask(regularTask.getId());
     Collection<Task> history = manager.getHistory();
 
     // Assert
@@ -618,36 +618,12 @@ public class InMemoryTaskManagerTest {
   }
 
   @Test
-  @DisplayName("History should remove oldest item when limit is reached")
-  void testHistoryRemovesOldestItemOnLimitReached() {
-    // Arrange
-    int historyLimit = 10;
-    List<RegularTask> tasks = new ArrayList<>(historyLimit + 1);
-    for (int i = 0; i < historyLimit + 1; i++) {
-      tasks.add(
-          manager.addTask(new RegularTaskCreationDTO(VALID_TITLE + i, VALID_DESCRIPTION + i)));
-    }
-
-    // Act
-    for (RegularTask task : tasks) {
-      manager.getTaskById(task.getId());
-    }
-
-    Collection<Task> history = manager.getHistory();
-
-    // Assert
-    assertEquals(historyLimit, history.size());
-    boolean firstTaskInHistory = history.stream().anyMatch(t -> t.getId() == tasks.get(0).getId());
-    assertFalse(firstTaskInHistory);
-  }
-
-  @Test
   @DisplayName("History should not contain deleted tasks")
   void testHistoryShouldNotContainDeletedTasks() {
     // Arrange
     RegularTask regularTask =
         manager.addTask(new RegularTaskCreationDTO(VALID_TITLE, VALID_DESCRIPTION));
-    manager.getTaskById(regularTask.getId());
+    manager.getTask(regularTask.getId());
     Collection<Task> historyBeforeDeletion = manager.getHistory();
     assertTrue(historyBeforeDeletion.stream().anyMatch(t -> t.getId() == regularTask.getId()));
 
@@ -665,11 +641,11 @@ public class InMemoryTaskManagerTest {
     // Arrange
     RegularTask regularTask =
         manager.addTask(new RegularTaskCreationDTO(VALID_TITLE, VALID_DESCRIPTION));
-    manager.getTaskById(regularTask.getId());
+    manager.getTask(regularTask.getId());
     int historySizeBefore = manager.getHistory().size();
 
     // Act
-    manager.getTaskById(9999);
+    manager.getTask(9999);
 
     // Assert
     int historySizeAfter = manager.getHistory().size();
@@ -679,7 +655,6 @@ public class InMemoryTaskManagerTest {
   @Test
   @DisplayName("History should be updated in correct order of task access")
   void testHistoryAccessOrder() {
-    // Arrange
     RegularTask task1 =
         manager.addTask(new RegularTaskCreationDTO(VALID_TITLE + "1", VALID_DESCRIPTION));
     RegularTask task2 =
@@ -687,16 +662,24 @@ public class InMemoryTaskManagerTest {
     RegularTask task3 =
         manager.addTask(new RegularTaskCreationDTO(VALID_TITLE + "3", VALID_DESCRIPTION));
 
-    // Act
-    manager.getTaskById(task1.getId());
-    manager.getTaskById(task2.getId());
-    manager.getTaskById(task3.getId());
+    manager.getTask(task1.getId());
+    manager.getTask(task2.getId());
+    manager.getTask(task3.getId());
 
-    // Assert
     List<Task> historyList = manager.getHistory().stream().toList();
     assertEquals(3, historyList.size());
     assertEquals(task1.getId(), historyList.get(0).getId());
     assertEquals(task2.getId(), historyList.get(1).getId());
     assertEquals(task3.getId(), historyList.get(2).getId());
+  }
+
+  @Test
+  @DisplayName("Should clear task from history when removed from repository")
+  void removeTaskFromHistoryOnRemoval() {
+    RegularTask task1 = manager.addTask(new RegularTaskCreationDTO(VALID_TITLE, VALID_DESCRIPTION));
+    manager.getTask(task1.getId());
+    assertEquals(1, manager.getHistory().size());
+    manager.removeTaskById(task1.getId());
+    assertEquals(0, manager.getHistory().size());
   }
 }

--- a/src/test/java/com/tasktracker/task/model/implementations/TaskViewTest.java
+++ b/src/test/java/com/tasktracker/task/model/implementations/TaskViewTest.java
@@ -50,7 +50,7 @@ class TaskViewTest {
   @DisplayName("equals should return false for different TaskView instances")
   void equals_DifferentInstances() {
     TaskView taskView1 = new TaskView(6, LocalDateTime.now());
-    TaskView taskView2 = new TaskView(6, LocalDateTime.now());
+    TaskView taskView2 = new TaskView(7, LocalDateTime.now());
     assertNotEquals(taskView1, taskView2, "Different TaskView instances should not be equal");
   }
 
@@ -68,40 +68,20 @@ class TaskViewTest {
   @DisplayName("hashCode should differ for different TaskView instances")
   void hashCode_DifferentInstances() {
     TaskView taskView1 = new TaskView(8, LocalDateTime.now());
-    TaskView taskView2 = new TaskView(8, LocalDateTime.now());
+    TaskView taskView2 = new TaskView(9, LocalDateTime.now());
     assertNotEquals(
         taskView1.hashCode(),
         taskView2.hashCode(),
         "Different TaskView instances should have different hashCodes");
   }
 
-  @Test
-  @DisplayName("compareTo should order TaskViews based on viewDateTime and taskId")
-  void compareTo_OrderBasedOnFields() {
-    LocalDateTime time1 = LocalDateTime.of(2023, 4, 1, 10, 0);
-    LocalDateTime time2 = LocalDateTime.of(2023, 4, 1, 11, 0);
-
-    TaskView taskView1 = new TaskView(9, time1);
-    TaskView taskView2 = new TaskView(10, time1);
-    TaskView taskView3 = new TaskView(9, time2);
-
-    assertTrue(
-        taskView1.compareTo(taskView2) < 0,
-        "taskView1 should come before taskView2 based on taskId");
-    assertTrue(
-        taskView1.compareTo(taskView3) < 0,
-        "taskView1 should come before taskView3 based on viewDateTime");
-    assertTrue(
-        taskView3.compareTo(taskView1) > 0,
-        "taskView3 should come after taskView1 based on viewDateTime");
-  }
 
   @Test
   @DisplayName("compareTo should handle equal TaskViews correctly")
   void compareTo_EqualTaskViews() {
     LocalDateTime viewTime = LocalDateTime.of(2023, 6, 1, 9, 0);
     TaskView taskView1 = new TaskView(11, viewTime);
-    TaskView taskView2 = new TaskView(11, viewTime);
+    TaskView taskView2 = new TaskView(12, viewTime);
 
     assertNotEquals(
         taskView1.getTaskId(),

--- a/src/test/java/com/tasktracker/task/model/implementations/TaskViewTest.java
+++ b/src/test/java/com/tasktracker/task/model/implementations/TaskViewTest.java
@@ -14,21 +14,10 @@ class TaskViewTest {
     int taskId = 1;
     LocalDateTime viewTime = LocalDateTime.now();
     TaskView taskView = new TaskView(taskId, viewTime);
-
-    assertNotNull(taskView.getViewId());
     assertEquals(taskId, taskView.getTaskId());
     assertEquals(viewTime, taskView.getViewDateTime());
   }
 
-  @Test
-  @DisplayName("getViewId should return the correct UUID")
-  void getViewId() {
-    int taskId = 2;
-    LocalDateTime viewTime = LocalDateTime.now();
-    TaskView taskView = new TaskView(taskId, viewTime);
-
-    assertNotNull(taskView.getViewId());
-  }
 
   @Test
   @DisplayName("getViewDateTime should return the correct viewDateTime")
@@ -115,9 +104,9 @@ class TaskViewTest {
     TaskView taskView2 = new TaskView(11, viewTime);
 
     assertNotEquals(
-        taskView1.getViewId(),
-        taskView2.getViewId(),
-        "Different TaskViews should have different UUIDs");
+        taskView1.getTaskId(),
+        taskView2.getTaskId(),
+        "Different TaskViews should have different TaskIDs");
     assertNotEquals(
         0, taskView1.compareTo(taskView2), "Different TaskViews should not be equal in compareTo");
   }

--- a/src/test/java/com/tasktracker/task/store/InMemoryTaskRepositoryTest.java
+++ b/src/test/java/com/tasktracker/task/store/InMemoryTaskRepositoryTest.java
@@ -154,11 +154,11 @@ class InMemoryTaskRepositoryTest {
 
   @Test
   @DisplayName("Should remove a task by ID and return it")
-  void testRemoveTaskByIdValid() {
+  void testRemoveTaskValid() {
     RegularTask saved = createAndStoreTask("RemoveTaskXXXX", "RemoveDescrXXXX", TaskStatus.NEW);
     int assignedId = saved.getId();
 
-    Optional<Task> removed = repository.removeTaskById(assignedId);
+    Optional<Task> removed = repository.removeTask(assignedId);
     assertTrue(removed.isPresent(), "Should return the removed task");
     assertEquals(assignedId, removed.get().getId(), "Removed task ID should match");
     assertTrue(
@@ -167,10 +167,10 @@ class InMemoryTaskRepositoryTest {
 
   @Test
   @DisplayName("Should throw NoSuchElementException when removing a non-existent ID")
-  void testRemoveTaskByIdNonExistent() {
+  void testRemoveTaskNonExistent() {
     assertThrows(
         NoSuchElementException.class,
-        () -> repository.removeTaskById(12345),
+        () -> repository.removeTask(12345),
         "Removing a non-existent ID should throw NoSuchElementException");
   }
 


### PR DESCRIPTION
### Description

This pull request refactors the task history management system to improve API clarity, enhance performance, and simplify operations. Key changes include:

- Refactored `HistoryManager` with a new `put` method, replacing `add` for better clarity, and added a `remove` method for task deletion by ID.
- Simplified `InMemoryHistoryManager` by removing the history limit logic and optimizing data structure handling.
- Updated `TaskView` by removing unused attributes and focusing on task ID and creation timestamp. Improved consistency in methods like `toString`, `equals`, and `hashCode`. Simplified `compareTo` to rely solely on `taskId`.
- Aligned `Managers` factory class with `InMemoryHistoryManager` constructor adjustments.
- Unified API across the codebase by replacing `getTaskById` with `getTask`.
- Overhauled unit tests for improved coverage and compatibility with the changes.
- Added a new user scenario in the `Main` class showcasing task history operations, including updates and deletions. 

These changes enhance the system's clarity and usability, ensuring easier maintenance and future scalability.